### PR TITLE
JJBB: fix missing project type and main

### DIFF
--- a/.ci/jobs/apm-agent-ios-mbp.yml
+++ b/.ci/jobs/apm-agent-ios-mbp.yml
@@ -13,7 +13,7 @@
           discover-pr-origin: 'merge-current'
           discover-tags: true
           notification-context: 'apm-ci'
-          repo: apm-agent-php
+          repo: apm-agent-ios
           repo-owner: 'elastic'
           credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
           ssh-checkout:

--- a/.ci/jobs/apm-agent-ios-mbp.yml
+++ b/.ci/jobs/apm-agent-ios-mbp.yml
@@ -4,38 +4,36 @@
     display-name: APM Agent iOS
     description: APM Agent iOS
     script-path: .ci/Jenkinsfile
+    project-type: multibranch
     scm:
-    - github:
-        branch-discovery: no-pr
-        discover-pr-forks-strategy: merge-current
-        discover-pr-forks-trust: permission
-        discover-pr-origin: merge-current
-        discover-tags: true
-        notification-context: 'apm-ci'
-        repo: apm-agent-php
-        repo-owner: elastic
-        credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
-        ssh-checkout:
-          credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
-        build-strategies:
-        - tags:
-            ignore-tags-older-than: -1
-            ignore-tags-newer-than: -1
-        - regular-branches: true
-        - change-request:
-            ignore-target-only-changes: false
-        clean:
-          after: true
-          before: true
-        prune: true
-        shallow-clone: true
-        depth: 3
-        do-not-fetch-tags: true
-        submodule:
-          disable: false
-          recursive: true
-          parent-credentials: true
-          timeout: 100
-        timeout: '15'
-        use-author: true
-        wipe-workspace: 'True'
+      - github:
+          branch-discovery: no-pr
+          discover-pr-forks-strategy: 'merge-current'
+          discover-pr-forks-trust: 'permission'
+          discover-pr-origin: 'merge-current'
+          discover-tags: false
+          notification-context: 'apm-ci'
+          repo: apm-agent-php
+          repo-owner: 'elastic'
+          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          ssh-checkout:
+            credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          build-strategies:
+          - tags:
+              ignore-tags-older-than: -1
+              ignore-tags-newer-than: -1
+          - regular-branches: true
+          - change-request:
+              ignore-target-only-changes: false
+          prune: true
+          shallow-clone: true
+          depth: 3
+          do-not-fetch-tags: true
+          submodule:
+              disable: false
+              recursive: true
+              parent-credentials: true
+              timeout: 100
+          timeout: '15'
+          use-author: true
+          wipe-workspace: true

--- a/.ci/jobs/apm-agent-ios-mbp.yml
+++ b/.ci/jobs/apm-agent-ios-mbp.yml
@@ -11,7 +11,7 @@
           discover-pr-forks-strategy: 'merge-current'
           discover-pr-forks-trust: 'permission'
           discover-pr-origin: 'merge-current'
-          discover-tags: false
+          discover-tags: true
           notification-context: 'apm-ci'
           repo: apm-agent-php
           repo-owner: 'elastic'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://apm-ci.elastic.co/buildStatus/icon?job=apm-agent-ios%2Fapm-agent-ios-mbp%2Fmaster)](https://apm-ci.elastic.co/job/apm-agent-ios/job/apm-agent-ios-mbp/job/master/)
+[![Build Status](https://apm-ci.elastic.co/buildStatus/icon?job=apm-agent-ios%2Fapm-agent-ios-mbp%2Fmain)](https://apm-ci.elastic.co/job/apm-agent-ios/job/apm-agent-ios-mbp/job/main/)
 
 # apm-agent-ios : APM Agent for iOS
 This is the official iOS package for [Elastic APM](https://www.elastic.co/solutions/apm)


### PR DESCRIPTION
### What

JJBB syntax was incorrect, I used the wrong template :/

I also found the name of the default branch is `main`, so I changed the badge reference too.
