### PR TITLE
Initialize documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+# Elastic documentation
+html_docs

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,0 +1,24 @@
+////
+[[release-notes-x.x.x]]
+==== x.x.x - YYYY/MM/DD
+
+[float]
+===== Breaking changes
+
+[float]
+===== Features
+* Cool new feature: {pull}2526[#2526]
+
+[float]
+===== Bug fixes
+////
+
+[[release-notes-preview]]
+=== iOS Agent technical preview
+
+[discrete]
+[[release-notes-preview-1]]
+==== Technical preview
+
+// Using the template above, release notes go here.
+// append the version number of the release to the heading above

--- a/README.md
+++ b/README.md
@@ -3,5 +3,15 @@
 # apm-agent-ios : APM Agent for iOS
 This is the official iOS package for [Elastic APM](https://www.elastic.co/solutions/apm)
 
-This package is consider experimental and should not be used in production. 
+This package is consider experimental and should not be used in production.
 
+## Documentation
+
+To build the documentation for this project, you must first clone the [`elastic/docs` repository](https://github.com/elastic/docs/). Then run the following commands:
+
+```bash
+# Set the location of your repositories
+export GIT_HOME="/<fullPathToYourRepos>"
+# Build the APM iOS documentation
+$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-ios/docs/index.asciidoc --chunk 1 --open
+```

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1,0 +1,41 @@
+[[configuration]]
+== Configuration
+
+Configure the agent in the agent's `start()` function.
+
+// some config example that preferably is correct unlike mine
+[source,swift]
+----
+#import ""
+
+somethinggoesheremaybe({
+  otelCollectorAddress: '',
+  otelCollectorPort: '',
+})
+----
+
+[discrete]
+[[configuration-options]]
+=== Configuration options
+
+Available configuration options...
+
+[discrete]
+[[otelCollectorAddress]]
+==== `otelCollectorAddress`
+
+* *Type:* String
+* *Default:* `127.0.0.1`
+// * *Env:* ``
+
+The APM Server host.
+
+[discrete]
+[[otelCollectorPort]]
+==== `otelCollectorPort`
+
+* *Type:* Int
+* *Default:* `8200`
+// * *Env:* ``
+
+The APM Server port.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,0 +1,30 @@
+include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
+// **Uncomment when docs are added to the Elastic documentation build**
+// ifdef::env-github[]
+// NOTE: For the best reading experience,
+// please view this documentation at https://www.elastic.co/guide/en/apm/agent/ios[elastic.co]
+// endif::[]
+
+= APM iOS Agent Reference
+
+include::./intro.asciidoc[]
+
+include::./supported-tech.asciidoc[]
+
+include::./setup.asciidoc[]
+
+include::./configuration.asciidoc[]
+
+// include::./api.asciidoc[]
+
+// include::./metrics.asciidoc[]
+
+// include::./performance-tuning.asciidoc[]
+
+// include::./troubleshooting.asciidoc[]
+
+// include::./upgrading.asciidoc[]
+
+include::./release-notes.asciidoc[]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -1,0 +1,19 @@
+[[intro]]
+== Introduction
+
+The Elastic APM iOS Agent measures the performance of your mobile applications in real-time.
+
+// [float]
+// [[how-it-works]]
+// === How does the Agent work?
+
+// We should add something here about how the agent works. It probably makes sense to mention OTel here.
+
+// does it work in the foreground only? background too?
+
+[discrete]
+[[additional-components]]
+=== Additional Components
+APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[{es}], and {kibana-ref}/index.html[{kib}].
+The {apm-overview-ref-v}/index.html[APM Overview] provides details on how these components work together,
+and provides a matrix outlining {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility].

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -1,0 +1,8 @@
+:pull: https://github.com/elastic/apm-agent-ios/pull/
+
+[[release-notes]]
+== Release notes
+
+* <<release-notes-preview>>
+
+include::../CHANGELOG.asciidoc[]

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -1,0 +1,18 @@
+[[setup]]
+== Set up the Agent
+
+Set up the Agent by...
+
+[source,bash]
+----
+commands go in here
+----
+
+Then do this:
+
+[source,swift]
+----
+code goes in here
+----
+
+yay

--- a/docs/supported-tech.asciidoc
+++ b/docs/supported-tech.asciidoc
@@ -1,0 +1,17 @@
+[[supported-technologies]]
+== Supported technologies
+
+The Elastic APM iOS Agent automatically instruments various APIs, frameworks, and application servers. This section lists all supported technologies.
+
+// Tables work like this:
+
+// [options="header"]
+// |=======================================================================
+// |Framework |Version
+// |<<express,Express>> |^4.0.0
+// |<<hapi,hapi>> |>=9.0.0 <19.0.0
+// |<<hapi,@hapi/hapi>> |>=17.9.0 <20.0.0
+// |=======================================================================
+
+// Click the edit button on https://www.elastic.co/guide/en/apm/agent/php/current/supported-technologies.html
+// for more ideas


### PR DESCRIPTION
## Summary

This PR adds files and boilerplate content for Elastic documentation. @bryce-b, this is going to need quite a bit of additional input from your side 😅. Feel free to push to this PR if you'd like. Don't feel like you have to worry too much about formatting–I can always clean that up. Oh, and I added some questions as comments throughout.

Documentation build steps were added to the readme, but are also copied below. Ensure you have the [`elastic/docs` repository](https://github.com/elastic/docs/) cloned first.

```bash
# Set the location of your repositories
export GIT_HOME="/<fullPathToYourRepos>"
# Build the APM iOS documentation
$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-ios/docs/index.asciidoc --chunk 1 --open
```

For https://github.com/elastic/apm-agent-ios/issues/13.