### PR TITLE
docs: Add disclaimer and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ This package is considered experimental and should not be used in production.
 
 ## Documentation
 
-To build the documentation for this project, you must first clone the [`elastic/docs` repository](https://github.com/elastic/docs/). Then run the following commands:
+Visit [elastic.co](https://www.elastic.co/guide/en/apm/agent/swift/current/index.html) for the iOS agent documentation.
+
+To build this project's documentation locally, you must first clone the [`elastic/docs` repository](https://github.com/elastic/docs/). Then run the following commands:
 
 ```bash
 # Set the location of your repositories

--- a/docs/page_header.html
+++ b/docs/page_header.html
@@ -1,0 +1,2 @@
+You are looking at preliminary documentation for a future release.
+This project is still in development; do not use it in a production environment.


### PR DESCRIPTION
* Links from the project repo to the public documentation
* Adds a banner to the top of the public documentation:

<img width="765" alt="Screen Shot 2021-06-09 at 2 05 52 PM" src="https://user-images.githubusercontent.com/5618806/121429468-cfae1080-c92b-11eb-8d1a-aeb8aac81949.png">

For https://github.com/elastic/apm-agent-ios/issues/13

