### PR TITLE
added device.id to AgentResource

### DIFF
--- a/Sources/apm-agent-ios/Agent.swift
+++ b/Sources/apm-agent-ios/Agent.swift
@@ -51,13 +51,14 @@ public class Agent {
         group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     
         if configuration.collectorTLS {
-            channel = ClientConnection.secure(group: group).connect(host: configuration.collectorHost, port: configuration.collectorPort)
-
+            channel = ClientConnection.secure(group: group)
+                .connect(host: configuration.collectorHost, port: configuration.collectorPort)
         } else {
-            channel = ClientConnection.insecure(group: group).connect(host: configuration.collectorHost, port: configuration.collectorPort)
-
+            channel = ClientConnection.insecure(group: group)
+                .connect(host: configuration.collectorHost, port: configuration.collectorPort)
         }
-
+        
+        
         Agent.initializeMetrics(grpcClient: channel)
         Agent.initializeTracing(grpcClient: channel)
               

--- a/Sources/apm-agent-ios/AgentResource.swift
+++ b/Sources/apm-agent-ios/AgentResource.swift
@@ -13,6 +13,7 @@
 //   limitations under the License.
 
 import Foundation
+import UIKit
 import ResourceExtension
 import OpenTelemetryApi
 import OpenTelemetrySdk
@@ -24,8 +25,13 @@ public class AgentResource  {
             ResourceAttributes.telemetrySdkName.rawValue :  AttributeValue.string("iOS"),
         ]
         
+        
         if let agentVersion =  Bundle(for: self).infoDictionary?["CFBundleShortVersionString"] as? String {
             overridingAttributes[ResourceAttributes.telemetrySdkVersion.rawValue] =  AttributeValue.string(agentVersion)
+        }
+        
+        if let deviceId = UIDevice.current.identifierForVendor?.uuidString {
+            overridingAttributes["device.id"] = AttributeValue.string(deviceId)
         }
         
         return defaultResource.merging(other: Resource.init(attributes:overridingAttributes))


### PR DESCRIPTION
host.id is being mapped to a System.ID https://github.com/elastic/apm-server/blob/01a12f2b3ebfa78c2186270eb4771c6ff1d7a27b/model/system.go
which doesn't get mapped to any fields in ES. This PR adds device.id as a temporary fix.