### PR TITLE
OpenTelemetry-Swift -> v1.1.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/open-telemetry/opentelemetry-swift",
         "state": {
           "branch": null,
-          "revision": "90bcf2e413d6dfe0fb9f410e75bfa90d818965c9",
-          "version": "1.0.4"
+          "revision": "3f9d9d7b754f750bb8a1655796064a39e54b311b",
+          "version": "1.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .library(name: "CPUSampler", type: .static, targets: ["CPUSampler"]),
     ],
     dependencies: [
-        .package(name: "opentelemetry-swift", url: "https://github.com/open-telemetry/opentelemetry-swift", from: "1.0.4"),
+        .package(name: "opentelemetry-swift", url: "https://github.com/open-telemetry/opentelemetry-swift", from: "1.1.0"),
         .package(name: "Reachability", url: "https://github.com/ashleymills/Reachability.swift", from: "5.1.0"),
     ],
     targets: [

--- a/Sources/apm-agent-ios/Agent.swift
+++ b/Sources/apm-agent-ios/Agent.swift
@@ -70,7 +70,7 @@ public class Agent {
         otlpConfiguration = OtlpConfiguration(timeout: OtlpConfiguration.DefaultTimeoutInterval, headers: Self.generateMetadata(configuration.secretToken))
 
         if configuration.collectorTLS {
-            channel = ClientConnection.secure(group: group)
+            channel = ClientConnection.usingPlatformAppropriateTLS(for: group)
                 .connect(host: configuration.collectorHost, port: configuration.collectorPort)
         } else {
             channel = ClientConnection.insecure(group: group)


### PR DESCRIPTION
updated deprecated GRPC library `secure` api -> `usingPlatformAppropriateTLS`