### PR TITLE
docs: update broken links for apm-guide-ref

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -15,5 +15,5 @@ The agent also captures any custom open-telemetry traces or measurements created
 [[additional-components]]
 === Additional components
 APM Agents work in conjunction with the {apm-guide-ref}/index.html[APM Server], {ref}/index.html[{es}], and {kibana-ref}/index.html[{kib}].
-The {apm-guide-ref}/index.html[APM Overview] provides details on how these components work together,
+The {apm-guide-ref}/index.html[APM Guide] provides details on how these components work together,
 and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -15,5 +15,5 @@ The agent also captures any custom open-telemetry traces or measurements created
 [[additional-components]]
 === Additional components
 APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[{es}], and {kibana-ref}/index.html[{kib}].
-The {apm-overview-ref-v}/index.html[APM Overview] provides details on how these components work together,
-and provides a matrix outlining {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility].
+The {apm-guide-ref}/index.html[APM Overview] provides details on how these components work together,
+and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -14,6 +14,6 @@ The agent also captures any custom open-telemetry traces or measurements created
 [discrete]
 [[additional-components]]
 === Additional components
-APM Agents work in conjunction with the {apm-guide-ref-v}/index.html[APM Server], {ref}/index.html[{es}], and {kibana-ref}/index.html[{kib}].
+APM Agents work in conjunction with the {apm-guide-ref}/index.html[APM Server], {ref}/index.html[{es}], and {kibana-ref}/index.html[{kib}].
 The {apm-guide-ref}/index.html[APM Overview] provides details on how these components work together,
 and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -14,6 +14,6 @@ The agent also captures any custom open-telemetry traces or measurements created
 [discrete]
 [[additional-components]]
 === Additional components
-APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[{es}], and {kibana-ref}/index.html[{kib}].
+APM Agents work in conjunction with the {apm-guide-ref-v}/index.html[APM Server], {ref}/index.html[{es}], and {kibana-ref}/index.html[{kib}].
 The {apm-guide-ref}/index.html[APM Overview] provides details on how these components work together,
 and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].


### PR DESCRIPTION
Links updated as per elastic/observability-docs#1385. The old links will break when 7.17 releases. This PR and all backports must be merged before the 7.17 release. Thanks!

### Backports

- [ ] 0.x: https://github.com/elastic/apm-agent-ios/pull/64