### PR TITLE
ci: use github actions macos

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,6 +12,7 @@ on:
       - 8.*
       - "7.17"
 
+jobs:
   macos:
     runs-on: macos-10.15
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,24 @@
+name: macos
+
+on:
+  push:
+    branches:
+      - main
+      - 8.*
+      - "7.17"
+  pull_request:
+    branches:
+      - main
+      - 8.*
+      - "7.17"
+
+  macos:
+    runs-on: macos-10.15
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run build
+      run: .ci/scripts/build.sh
+
+    - name: Run test
+      run: xcodebuild -scheme apm-agent-ios-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 8' test


### PR DESCRIPTION
We are in the transition to use ephemeral workers, but until then there is a requirement to decommission the existing MacOS workers. For such this proposal uses GitHub actions for MacOS until we can use the ephemeral workers.