### PR TITLE
Updated view controller instrumentation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,17 +6,17 @@
         "repositoryURL": "https://github.com/grpc/grpc-swift.git",
         "state": {
           "branch": null,
-          "revision": "14e1ea3350892a864386517c037e11fb68baf818",
-          "version": "1.3.0"
+          "revision": "d7961746769616d0b81bda771de5648ebfa1abf9",
+          "version": "1.7.1"
         }
       },
       {
         "package": "opentelemetry-swift",
-        "repositoryURL": "https://github.com/open-telemetry/opentelemetry-swift",
+        "repositoryURL": "https://github.com/AlexanderWert/opentelemetry-swift",
         "state": {
-          "branch": null,
-          "revision": "3f9d9d7b754f750bb8a1655796064a39e54b311b",
-          "version": "1.1.0"
+          "branch": "alex-test",
+          "revision": "76a208863584787d12f3e94d2ab2820264ef88a5",
+          "version": null
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-atomics.git",
         "state": {
           "branch": null,
-          "revision": "3e95ba32cd1b4c877f6163e8eea54afc4e63bf9f",
-          "version": "0.0.3"
+          "revision": "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
+          "version": "1.0.2"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "94f41c4121a82fae5c7b1cb03e630e9f9e5e20f1",
-          "version": "2.32.1"
+          "revision": "154f1d32366449dcccf6375a173adf4ed2a74429",
+          "version": "2.38.0"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "f72c4688f89c28502105509186eadc49a49cb922",
-          "version": "1.10.0"
+          "revision": "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
+          "version": "1.10.2"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "42bdcae4ac4913507a5ee7af963c559deb60d1fc",
-          "version": "1.18.2"
+          "revision": "000ca94f9de92c95b9ac85d44600b7b0fe25a3e5",
+          "version": "1.19.2"
         }
       },
       {
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "4829979d9f5ed9a2f4c6efd9c1ed51d1ab4d0394",
-          "version": "2.14.1"
+          "revision": "52a486ff6de9bc3e26bf634c5413c41c5fa89ca5",
+          "version": "2.17.2"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "9571a61d236c5253b6a255a2d13fac536a1e2625",
-          "version": "1.11.2"
+          "revision": "8ab824b140d0ebcd87e9149266ddc353e3705a3e",
+          "version": "1.11.4"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "1f62db409f2c9b0223a3f68567b4a01333aae778",
-          "version": "1.17.0"
+          "revision": "e1499bc69b9040b29184f7f2996f7bab467c1639",
+          "version": "1.19.0"
         }
       },
       {

--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ export GIT_HOME="/<fullPathToYourRepos>"
 # Build the APM iOS documentation
 $GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-ios/docs/index.asciidoc --chunk 1 --open
 ```
+
+## Notes
+
+### disabling noisy logs
+
+- CoreTelephony in simulator
+```xcrun simctl spawn booted log config --mode "level:off" --subsystem com.apple.CoreTelephony```
+
+- Layout Constraints warnings
+```xcrun simctl spawn booted log config --mode "level:off" --subsystem com.apple
+.UIKit```

--- a/Sources/apm-agent-ios/Agent.swift
+++ b/Sources/apm-agent-ios/Agent.swift
@@ -97,7 +97,7 @@ public class Agent {
                 _ = spanData[i].settingResource(newResource)
             }
         }
-
+        OpenTelemetry.registerContextManager(contextManager: SimpleActivityContextManager.instance)
         OpenTelemetry.registerTracerProvider(tracerProvider: TracerProviderBuilder()
             .add(spanProcessor: b)
             .with(resource: AgentResource.get().merging(other: AgentEnvResource.resource))

--- a/Sources/apm-agent-ios/Instrumentation/ActivityStack.swift
+++ b/Sources/apm-agent-ios/Instrumentation/ActivityStack.swift
@@ -1,0 +1,32 @@
+//
+//  ActivityStack.swift
+//
+//
+//  Created by Alexander Wert on 7/13/22.
+//
+
+import Foundation
+import os.activity
+
+struct ActivityStack {
+    
+    private var items: [AnyObject] = []
+
+    
+    func peek() -> AnyObject {
+        guard let topElement = items.first else { fatalError("This stack is empty.") }
+        return topElement
+    }
+    
+    mutating func pop() -> AnyObject {
+        return items.removeFirst()
+    }
+  
+    mutating func push(_ element: AnyObject) {
+        items.insert(element, at: 0)
+    }
+    
+    mutating func remove(_ element: AnyObject) {
+        items.removeAll(where: {$0 === element})
+    }
+}

--- a/Sources/apm-agent-ios/Instrumentation/SimpleActivityContextManager.swift
+++ b/Sources/apm-agent-ios/Instrumentation/SimpleActivityContextManager.swift
@@ -1,0 +1,107 @@
+// Copyright © 2022 Elasticsearch BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+import Foundation
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import os
+
+
+class SimpleActivityContextManager : ContextManager {
+    private let logger = OSLog(subsystem: "co.elastic.simpleActivityContextManager", category: "TracingContext")
+    static let instance = SimpleActivityContextManager()
+    
+    private let rlock = NSRecursiveLock()
+    private var contextMap = [SpanId : [String: ActivityStack]]()
+    private var rootToActivityMap = NSMapTable<AnyObject, Activity>(keyOptions:.weakMemory,valueOptions: .strongMemory)
+    private var activityStack = [Activity]()
+    
+    class Activity {
+        
+        var id: SpanId
+        init(id: SpanId) {
+            self.id = id
+        }
+    }
+
+    func getCurrentContextValue(forKey key: OpenTelemetryApi.OpenTelemetryContextKeys) -> AnyObject? {
+        rlock.lock()
+        defer {
+            rlock.unlock()
+        }
+        if let activity = activityStack.last, let context = contextMap[activity.id] {
+            os_log("instance[0x%x] has Current Activity: %s",log: logger, type: .debug,unsafeBitCast(self, to: Int.self), activity.id.hexString)
+            return context[key.rawValue]?.peek()
+        }
+        
+        os_log("instance[0x%x] has no current context.",log: logger, type: .debug,unsafeBitCast(self, to: Int.self))
+        return nil
+    }
+    
+    func setCurrentContextValue(forKey key: OpenTelemetryApi.OpenTelemetryContextKeys, value: AnyObject) {
+        rlock.lock()
+        defer {
+            rlock.unlock()
+        }
+       
+        if let span = value as? RecordEventsReadableSpan  {
+            if contextMap[span.context.spanId] == nil || contextMap[span.context.spanId]?[key.rawValue] == nil {
+                os_log("instance[0x%x] created activity: %s",log: logger, type: .debug,unsafeBitCast(self, to: Int.self), span.context.spanId.hexString)
+                rootToActivityMap.setObject(Activity(id:span.context.spanId), forKey: value)
+                contextMap[span.context.spanId] = [String: ActivityStack]()
+                contextMap[span.context.spanId]?[key.rawValue] = ActivityStack()
+            }
+            contextMap[span.context.spanId]?[key.rawValue]?.push(value)
+            activityStack.append(Activity(id: span.context.spanId))
+          }
+    }
+    
+    func removeContextValue(forKey key: OpenTelemetryApi.OpenTelemetryContextKeys, value: AnyObject) {
+        rlock.lock()
+        defer {
+            rlock.unlock()
+        }
+        if let id = rootToActivityMap.object(forKey: value)?.id {
+                self.rlock.lock()
+                defer {
+                    self.rlock.unlock()
+                }
+                if self.contextMap[id] != nil && self.contextMap[id]!.isEmpty {
+                    self.contextMap.removeValue(forKey: id)
+                }
+                self.rootToActivityMap.removeObject(forKey: value)
+                self.activityStack.removeAll { a in
+                    if let v = value as? Activity {
+                        return a.id.hexString == v.id.hexString
+                    }
+                    return false
+                }
+            
+        } else {
+            if let span = value as? RecordEventsReadableSpan    {
+                if var stack = contextMap[span.context.spanId]?[key.rawValue] {
+                    stack.remove(value)
+                    self.activityStack.removeAll { a in
+                        if let v = value as? Activity {
+                            return a.id.hexString == v.id.hexString
+                        }
+                        return false
+                    }
+                }
+            }
+        }
+    }
+    
+
+}

--- a/Sources/apm-agent-ios/Instrumentation/TraceLogger.swift
+++ b/Sources/apm-agent-ios/Instrumentation/TraceLogger.swift
@@ -11,48 +11,90 @@
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
-
+#if os(iOS)
 import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
+import SwiftUI
+import UIKit
+import os
+
 
 class TraceLogger {
     private static var objectKey: UInt8 = 0
     private static var timerKey: UInt8 = 0
-    @objc static func didEnterBackground() {
-        OpenTelemetrySDK.instance.contextProvider.activeSpan?.addEvent(name: "application entered background")
-    }
-
-    static func setDate(on object: AnyObject) {
-        objc_setAssociatedObject(object, UnsafeRawPointer(&Self.timerKey), Date(), objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
-    }
-
-    static func fetchDate(from object: AnyObject) -> Date? {
-        let date = objc_getAssociatedObject(object, UnsafeRawPointer(&Self.timerKey)) as? Date
-        objc_setAssociatedObject(object, UnsafeRawPointer(&Self.timerKey), nil, objc_AssociationPolicy.OBJC_ASSOCIATION_ASSIGN)
-        return date
-    }
-
-    static func startTrace(tracer: TracerSdk, associatedObject: AnyObject, name: String) -> Span {
-        guard let previousSpan = objc_getAssociatedObject(associatedObject, UnsafeRawPointer(&Self.objectKey)) as? OpenTelemetryApi.Span else {
+    private var activeSpan : Span? = nil
+    private let spanLock = NSRecursiveLock()
+    private let logger = OSLog(subsystem: "co.elastic.viewControllerInstrumentation", category: "Instrumentation")
+    
+    func startTrace(tracer: TracerSdk, associatedObject: AnyObject, name: String, preferredName: String?) -> Span? {
+        spanLock.lock()
+        defer {
+            spanLock.unlock()
+        }
+        guard let activeSpan = getActiveSpan() else {
             let builder = tracer.spanBuilder(spanName: "\(name)")
+                .setActive(true)
                 .setSpanKind(spanKind: .client)
-
+            
             let span = builder.startSpan()
+            span.setAttribute(key: "type", value: AttributeValue.string("mobile"))
+            
+            os_log("Starting trace: %@ - %@ - %@",log:logger,type:.debug,name, span.context.traceId.description, span.context.spanId.description)
             span.setAttribute(key: "session.id", value: SessionManager.instance.session())
-            OpenTelemetrySDK.instance.contextProvider.setActiveSpan(span)
-
-            objc_setAssociatedObject(associatedObject, UnsafeRawPointer(&Self.objectKey), span, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
+            setActiveSpan(span)
+            setAssociatedSpan(associatedObject,span)
             return span
         }
-        return previousSpan
+        if let preferredName = preferredName, activeSpan.name != preferredName {
+            os_log("renaming trace: %@ -> %@ - %@ - %@", log:logger, type:.debug, activeSpan.name, preferredName, activeSpan.context.traceId.description, activeSpan.context.spanId.description)
+                activeSpan.name = preferredName
+    
+        }
+        return activeSpan
     }
-
-    static func stopTrace(associatedObject: AnyObject) {
-        if let span = objc_getAssociatedObject(associatedObject, UnsafeRawPointer(&Self.objectKey)) as? Span {
-            span.status = .ok
-            span.end()
-            objc_setAssociatedObject(associatedObject, UnsafeRawPointer(&Self.objectKey), nil, objc_AssociationPolicy.OBJC_ASSOCIATION_ASSIGN)
+    
+    func stopTrace(associatedObject: AnyObject) {
+        spanLock.lock()
+        defer {
+            spanLock.unlock()
+        }
+        if let associatedSpan = getAssociatedSpan(associatedObject), associatedSpan === getActiveSpan() {
+            os_log("Stopping trace: %@ - %@ - %@", log:logger, type:.debug,associatedSpan.name,associatedSpan.context.traceId.description, associatedSpan.context.spanId.description)
+            associatedSpan.status = .ok
+            associatedSpan.end()
+            clearAssociatedSpan(associatedObject)
+            setActiveSpan(nil)
         }
     }
+
+    func setActiveSpan(_ span: Span?) {
+        spanLock.lock()
+        defer {
+            spanLock.unlock()
+        }
+        activeSpan = span
+    }
+    func getActiveSpan() -> Span? {
+        spanLock.lock()
+        defer {
+            spanLock.unlock()
+        }
+        return activeSpan
+        /* contextProvider isn't dependible at this time */
+        // return OpenTelemetry.instance.contextProvider.activeSpan
+    }
+
+    func setAssociatedSpan(_ vc: AnyObject, _ span: Span) {
+        objc_setAssociatedObject(vc, UnsafeRawPointer(&Self.objectKey), span, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
+    }
+    func getAssociatedSpan(_ vc: AnyObject) -> Span? {
+        return objc_getAssociatedObject(vc, UnsafeRawPointer(&Self.objectKey)) as? OpenTelemetryApi.Span
+    }
+    func clearAssociatedSpan(_ vc: AnyObject) {
+        objc_setAssociatedObject(vc, UnsafeRawPointer(&Self.objectKey), nil, objc_AssociationPolicy.OBJC_ASSOCIATION_ASSIGN)
+
+    }
+        
 }
+#endif // #if os(iOS)

--- a/Sources/apm-agent-ios/Instrumentation/TraceLogger.swift
+++ b/Sources/apm-agent-ios/Instrumentation/TraceLogger.swift
@@ -40,7 +40,7 @@ class TraceLogger {
             let span = builder.startSpan()
             span.setAttribute(key: "type", value: AttributeValue.string("mobile"))
             
-            os_log("Starting trace: %@ - %@ - %@",log:logger,type:.debug,name, span.context.traceId.description, span.context.spanId.description)
+            os_log("Started trace: %@ - %@ - %@",log:logger,type:.debug,name, span.context.traceId.description, span.context.spanId.description)
             span.setAttribute(key: "session.id", value: SessionManager.instance.session())
             setActiveSpan(span)
             setAssociatedSpan(associatedObject,span)

--- a/Sources/apm-agent-ios/Instrumentation/UIApplicationInstrumentation.swift
+++ b/Sources/apm-agent-ios/Instrumentation/UIApplicationInstrumentation.swift
@@ -35,7 +35,7 @@ import Foundation
         }
 
         func swizzle() {
-            sendEvent.swizzle()
+            //sendEvent.swizzle()
         }
 
         class SendEvent: MethodSwizzler<

--- a/Sources/apm-agent-ios/Instrumentation/ViewControllerInstrumentation.swift
+++ b/Sources/apm-agent-ios/Instrumentation/ViewControllerInstrumentation.swift
@@ -20,6 +20,16 @@
     import UIKit
     import os
 
+
+@available(iOS 13.0, *)
+public extension View {
+
+    func reportName(_ name: String) -> Self {
+        OpenTelemetry.instance.contextProvider.activeSpan?.name = name
+        return self
+    }
+}
+
     internal class ViewControllerInstrumentation {
         static let logger = OSLog(subsystem: "co.elastic.viewControllerInstrumentation", category: "Instrumentation")
         var activeSpan : Span? = nil
@@ -130,4 +140,8 @@
             }
     }
 
+
 #endif // #if os(iOS)
+
+
+

--- a/Sources/apm-agent-ios/Instrumentation/ViewControllerInstrumentation.swift
+++ b/Sources/apm-agent-ios/Instrumentation/ViewControllerInstrumentation.swift
@@ -20,26 +20,16 @@
     import UIKit
 
     internal class ViewControllerInstrumentation {
-        let loadView: LoadView
+        var activeSpan : Span? = nil
+        static let traceLogger = TraceLogger()
         let viewDidLoad: ViewDidLoad
         let viewWillAppear: ViewWillAppear
         let viewDidAppear: ViewDidAppear
-        let viewDidDisappear: ViewDidDisappear
-        let viewWillDisappear: ViewWillDisappear
-        let viewWillLayoutSubviews: ViewWillLayoutSubviews
-        let viewDidLayoutSubviews: ViewDidLayoutSubviews
-        let transition: Transition
+
         init() throws {
-            loadView = try LoadView.build()
             viewDidLoad = try ViewDidLoad.build()
             viewWillAppear = try ViewWillAppear.build()
             viewDidAppear = try ViewDidAppear.build()
-            viewDidDisappear = try ViewDidDisappear.build()
-            viewWillDisappear = try ViewWillDisappear.build()
-            viewWillLayoutSubviews = try ViewWillLayoutSubviews.build()
-            viewDidLayoutSubviews = try ViewDidLayoutSubviews.build()
-            transition = try Transition.build()
-            NotificationCenter.default.addObserver(TraceLogger.self, selector: #selector(TraceLogger.didEnterBackground), name: UIApplication.willResignActiveNotification, object: nil)
         }
 
         deinit {
@@ -47,44 +37,16 @@
         }
 
         func swizzle() {
-            loadView.swizzle()
             viewDidLoad.swizzle()
             viewWillAppear.swizzle()
             viewDidAppear.swizzle()
-            viewDidDisappear.swizzle()
-            viewWillDisappear.swizzle()
-            transition.swizzle()
-            viewWillLayoutSubviews.swizzle()
-            viewDidLayoutSubviews.swizzle()
         }
 
         static func getTracer() -> TracerSdk {
-            OpenTelemetrySDK.instance.tracerProvider.get(instrumentationName: "UIViewController", instrumentationVersion: "0.0.1") as! TracerSdk
+            OpenTelemetrySDK.instance.tracerProvider.get(instrumentationName: "UIViewController", instrumentationVersion: "0.0.2") as! TracerSdk
         }
 
-        class LoadView: MethodSwizzler<
-        @convention(c) (UIViewController, Selector) -> Void,
-            @convention(block) (UIViewController) -> Void
-            >
-            {
-                static func build() throws -> LoadView {
-                    try LoadView(selector: #selector(UIViewController.loadView), klass: UIViewController.self)
-                }
-
-                func swizzle() {
-                    swap { previousImplementation -> BlockSignature in
-                        { viewController -> Void in
-                            let name = "\(type(of: viewController)).loadView()"
-                            _ = TraceLogger.startTrace(tracer: ViewControllerInstrumentation.getTracer(), associatedObject: viewController, name: name)
-
-                            previousImplementation(viewController, self.selector)
-
-                            TraceLogger.stopTrace(associatedObject: viewController)
-                        }
-                    }
-                }
-            }
-
+        
         class ViewDidLoad: MethodSwizzler<
         @convention(c) (UIViewController, Selector) -> Void, // IMPSignature
             @convention(block) (UIViewController) -> Void // BlockSignature
@@ -94,56 +56,20 @@
                     try ViewDidLoad(selector: #selector(UIViewController.viewDidLoad), klass: UIViewController.self)
                 }
 
-                func swizzle() {
-                    swap { previousImplementation -> BlockSignature in
-                        { viewController -> Void in
-                            let name = "\(type(of: viewController)).viewDidLoad()"
-                            _ = TraceLogger.startTrace(tracer: ViewControllerInstrumentation.getTracer(), associatedObject: viewController, name: name)
+                    func swizzle() {
+                        swap { previousImplementation -> BlockSignature in
+                            { viewController -> Void in
+                                
+                            var title = viewController.navigationItem.title
+                                
+                            if let navTitle = title {
+                                title = "\(navTitle) - view appearing"
+                            }
+                                
+                            let name = "\(type(of: viewController)) - view appearing"
+                            
+                            _ = ViewControllerInstrumentation.traceLogger.startTrace(tracer: ViewControllerInstrumentation.getTracer(), associatedObject: viewController, name: name, preferredName: title)
                             previousImplementation(viewController, self.selector)
-
-                            TraceLogger.stopTrace(associatedObject: viewController)
-                        }
-                    }
-                }
-            }
-
-        class AddChild: MethodSwizzler<
-        @convention(c) (UIViewController, Selector, UIViewController) -> Void,
-            @convention(block) (UIViewController, UIViewController) -> Void
-        >{
-            static func build() throws -> AddChild {
-                try AddChild(selector: #selector(UIViewController.addChild), klass: UIViewController.self)
-            }
-
-            func swizzle() {
-                swap { previousImplementation -> BlockSignature in
-                    { viewController, child -> Void in
-                        let name = "\(type(of: child)) added to \(type(of: viewController))"
-                        _ = TraceLogger.startTrace(tracer: ViewControllerInstrumentation.getTracer(), associatedObject: viewController, name: name)
-                        previousImplementation(viewController, self.selector, child)
-                        TraceLogger.stopTrace(associatedObject: viewController)
-                    }
-                }
-            }
-        }
-
-        class Transition: MethodSwizzler <
-        @convention(c) (UIViewController, Selector, UIViewController, UIViewController, TimeInterval, UIView.AnimationOptions, (() -> Void)?, ((Bool) -> Void)?) -> Void,
-            @convention(block) (UIViewController, UIViewController, UIViewController, TimeInterval, UIView.AnimationOptions, (() -> Void)?, ((Bool) -> Void)?) -> Void
-
-            >
-            {
-                static func build() throws -> Transition {
-                    try Transition(selector: #selector(UIViewController.transition), klass: UIViewController.self)
-                }
-
-                func swizzle() {
-                    swap { previousImplementaion -> BlockSignature in
-                        { viewController, from, to, duration, options, animations, completion -> Void in
-                            let name = "\(type(of: viewController)) transitioning to \(type(of: to)) from \(type(of: from))"
-                            _ = TraceLogger.startTrace(tracer: ViewControllerInstrumentation.getTracer(), associatedObject: viewController, name: name)
-                            previousImplementaion(viewController, self.selector, from, to, duration, options, animations, completion)
-                            TraceLogger.stopTrace(associatedObject: viewController)
                         }
                     }
                 }
@@ -161,13 +87,17 @@
                 func swizzle() {
                     swap { previousImplementation -> BlockSignature in
                         { viewController, animated -> Void in
+                            var title = viewController.navigationItem.title
+                            
+                            if let navTitle = title {
+                                title = "\(navTitle) - view appearing"
+                            }
+                                                    
+                            let name = "\(type(of: viewController)) - view appearing"
 
-                            let name = "\(type(of: viewController)).viewWillAppear()"
-
-                           _ = TraceLogger.startTrace(tracer: ViewControllerInstrumentation.getTracer(), associatedObject: viewController, name: name)
+                            _ = ViewControllerInstrumentation.traceLogger.startTrace(tracer: ViewControllerInstrumentation.getTracer(), associatedObject: viewController, name: name, preferredName: title)
 
                             previousImplementation(viewController, self.selector, animated)
-                            TraceLogger.stopTrace(associatedObject: viewController)
                         }
                     }
                 }
@@ -181,99 +111,11 @@
                 static func build() throws -> ViewDidAppear {
                     try ViewDidAppear(selector: #selector(UIViewController.viewDidAppear), klass: UIViewController.self)
                 }
-
                 func swizzle() {
                     swap { previousImplementation -> BlockSignature in
                         { viewController, animated -> Void in
-                            let name = "\(type(of: viewController)).viewDidAppear()"
-                           _ = TraceLogger.startTrace(tracer: ViewControllerInstrumentation.getTracer(), associatedObject: viewController, name: name)
-                            TraceLogger.setDate(on: viewController)
                             previousImplementation(viewController, self.selector, animated)
-                            TraceLogger.stopTrace(associatedObject: viewController)
-                        }
-                    }
-                }
-            }
-
-        class ViewDidDisappear: MethodSwizzler<
-        @convention(c) (UIViewController, Selector, Bool) -> Void, // IMPSignature
-            @convention(block) (UIViewController, Bool) -> Void // BlockSignature
-            >
-            {
-                static func build() throws -> ViewDidDisappear {
-                    try ViewDidDisappear(selector: #selector(UIViewController.viewDidDisappear), klass: UIViewController.self)
-                }
-
-                func swizzle() {
-                    swap { previousImplementation -> BlockSignature in
-                        { viewController, animated -> Void in
-                            let span = TraceLogger.startTrace(tracer: ViewControllerInstrumentation.getTracer(), associatedObject: viewController, name: "\(type(of: viewController)).viewDidDisappear()")
-                            previousImplementation(viewController, self.selector, animated)
-                            if let startDate = TraceLogger.fetchDate(from: viewController) {
-                                let displayDuration = Date().timeIntervalSince(startDate).toNanoseconds
-                                span.setAttribute(key: "displayDuration", value: AttributeValue.int(Int(displayDuration)))
-                            }
-                            TraceLogger.stopTrace(associatedObject: viewController)
-                        }
-                    }
-                }
-            }
-
-        class ViewWillDisappear: MethodSwizzler<
-        @convention(c) (UIViewController, Selector, Bool) -> Void, // IMPSignature
-            @convention(block) (UIViewController, Bool) -> Void // BlockSignature
-            >
-            {
-                static func build() throws -> ViewWillDisappear {
-                    try ViewWillDisappear(selector: #selector(UIViewController.viewWillDisappear), klass: UIViewController.self)
-                }
-
-                func swizzle() {
-                    swap { previousImplementation -> BlockSignature in
-                        { viewController, animated -> Void in
-                            _ = TraceLogger.startTrace(tracer: ViewControllerInstrumentation.getTracer(), associatedObject: viewController, name: "\(type(of: viewController)).viewWillDisappear()")
-                            previousImplementation(viewController, self.selector, animated)
-                            TraceLogger.stopTrace(associatedObject: viewController)
-                        }
-                    }
-                }
-            }
-
-        class ViewWillLayoutSubviews: MethodSwizzler <
-        @convention(c) (UIViewController, Selector) -> Void,
-            @convention(block) (UIViewController) -> Void
-            >
-            {
-                static func build() throws -> ViewWillLayoutSubviews {
-                    try ViewWillLayoutSubviews(selector: #selector(UIViewController.viewWillLayoutSubviews), klass: UIViewController.self)
-                }
-
-                func swizzle() {
-                    swap { previousImplementation -> BlockSignature in
-                        { viewController -> Void in
-                           _ = TraceLogger.startTrace(tracer: ViewControllerInstrumentation.getTracer(), associatedObject: viewController, name: "\(type(of: viewController)).viewWillLayoutSubviews()")
-                            previousImplementation(viewController, self.selector)
-                            TraceLogger.stopTrace(associatedObject: viewController)
-                        }
-                    }
-                }
-            }
-
-        class ViewDidLayoutSubviews: MethodSwizzler <
-        @convention(c) (UIViewController, Selector) -> Void,
-            @convention(block) (UIViewController) -> Void
-            >
-            {
-                static func build() throws -> ViewDidLayoutSubviews {
-                    try ViewDidLayoutSubviews(selector: #selector(UIViewController.viewDidLayoutSubviews), klass: UIViewController.self)
-                }
-
-                func swizzle() {
-                    swap { previousImpelmentation -> BlockSignature in
-                        { viewController -> Void in
-                            _ = TraceLogger.startTrace(tracer: ViewControllerInstrumentation.getTracer(), associatedObject: viewController, name: "\(type(of: viewController)).viewWillLayoutSubviews()")
-                            previousImpelmentation(viewController, self.selector)
-                            TraceLogger.stopTrace(associatedObject: viewController)
+                            ViewControllerInstrumentation.traceLogger.stopTrace(associatedObject: viewController)
                         }
                     }
                 }

--- a/Sources/apm-agent-ios/Instrumentation/ViewControllerInstrumentation.swift
+++ b/Sources/apm-agent-ios/Instrumentation/ViewControllerInstrumentation.swift
@@ -18,8 +18,10 @@
     import OpenTelemetrySdk
     import SwiftUI
     import UIKit
+    import os
 
     internal class ViewControllerInstrumentation {
+        static let logger = OSLog(subsystem: "co.elastic.viewControllerInstrumentation", category: "Instrumentation")
         var activeSpan : Span? = nil
         static let traceLogger = TraceLogger()
         let viewDidLoad: ViewDidLoad
@@ -67,7 +69,10 @@
                             }
                                 
                             let name = "\(type(of: viewController)) - view appearing"
-                            
+                                let className = "\(type(of: viewController))"
+
+                            os_log("instance[0x%x] called -[%s viewDidLoad]",log:ViewControllerInstrumentation.logger,type:.debug,unsafeBitCast(self, to: Int.self), className)
+
                             _ = ViewControllerInstrumentation.traceLogger.startTrace(tracer: ViewControllerInstrumentation.getTracer(), associatedObject: viewController, name: name, preferredName: title)
                             previousImplementation(viewController, self.selector)
                         }
@@ -96,7 +101,8 @@
                             let name = "\(type(of: viewController)) - view appearing"
 
                             _ = ViewControllerInstrumentation.traceLogger.startTrace(tracer: ViewControllerInstrumentation.getTracer(), associatedObject: viewController, name: name, preferredName: title)
-
+                            let className = "\(type(of: viewController))"
+                            os_log("instance[0x%x] called -[%s ViewWillAppear]",log:ViewControllerInstrumentation.logger,type:.debug, unsafeBitCast(self, to: Int.self), className)
                             previousImplementation(viewController, self.selector, animated)
                         }
                     }
@@ -114,6 +120,8 @@
                 func swizzle() {
                     swap { previousImplementation -> BlockSignature in
                         { viewController, animated -> Void in
+                            let className = "\(type(of: viewController))"
+                            os_log("instance[0x%x] called -[%s viewDidAppear]",log:ViewControllerInstrumentation.logger,type:.debug, unsafeBitCast(self, to: Int.self), className)
                             previousImplementation(viewController, self.selector, animated)
                             ViewControllerInstrumentation.traceLogger.stopTrace(associatedObject: viewController)
                         }


### PR DESCRIPTION
current view controller span is internally managed in instrumentation.


Context propagation is still not working quite right, which results in missing sub-spans in the first view controller trace. This is due to the strange bug in the OS Activity framework used for context propagation.