### PR TITLE
Add api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,4 @@ $GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-ios/docs/index.asciidoc --ch
 ```xcrun simctl spawn booted log config --mode "level:off" --subsystem com.apple.CoreTelephony```
 
 - Layout Constraints warnings
-```xcrun simctl spawn booted log config --mode "level:off" --subsystem com.apple
-.UIKit```
+```xcrun simctl spawn booted log config --mode "level:off" --subsystem com.apple.UIKit```

--- a/Sources/apm-agent-ios/AgentConfigBuilder.swift
+++ b/Sources/apm-agent-ios/AgentConfigBuilder.swift
@@ -16,7 +16,9 @@ import Foundation
 
 public class AgentConfigBuilder {
     var url : URL?
-    var secretToken : String?
+    var auth : String?
+    static let bearer = "bearer"
+    static let api = "ApiKey"
     
     public init() {}
     
@@ -25,8 +27,13 @@ public class AgentConfigBuilder {
         return self
     }
     
-    public func withSecretToken(_ token: String) ->Self {
-        self.secretToken = secretToken
+    public func withSecretToken(_ token: String) -> Self {
+        self.auth = "\(Self.bearer) \(token)"
+        return self
+    }
+    
+    public func withApiKey(_ key: String) -> Self {
+        self.auth = "\(Self.api) \(key)"
         return self
     }
     
@@ -43,8 +50,8 @@ public class AgentConfigBuilder {
             if let port = url.port {
                 config.collectorPort = port
             }
-            if let secret = secretToken {
-                config.secretToken = secret
+            if let auth = self.auth {
+                config.auth = auth
             }
         }
         return config

--- a/Sources/apm-agent-ios/AgentConfiguration.swift
+++ b/Sources/apm-agent-ios/AgentConfiguration.swift
@@ -12,5 +12,15 @@ public struct AgentConfiguration {
     public var collectorHost = "127.0.0.1"
     public var collectorPort = 8200
     public var collectorTLS = false
-    public var secretToken : String? = nil
+    var auth : String? = nil
+    var token : String? = nil
+    public var secretToken : String {
+        set (token) {
+            self.token = token
+            auth = "\(AgentConfigBuilder.bearer) \(token)"
+        }
+        get {
+            return token ?? ""
+        }
+    }
 }

--- a/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
+++ b/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
@@ -29,12 +29,10 @@ class OpenTelemetryInitializer {
     struct Headers {
         static let userAgent = "user-agent"
         static let authorization = "authorization"
-        static let bearer = "bearer"
-        static let api = "ApiKey"
     }
 
     static func initialize(_ configuration : AgentConfiguration) -> EventLoopGroup {
-        let otlpConfiguration = OtlpConfiguration(timeout: OtlpConfiguration.DefaultTimeoutInterval, headers: Self.generateExporterHeaders(configuration.secretToken))
+        let otlpConfiguration = OtlpConfiguration(timeout: OtlpConfiguration.DefaultTimeoutInterval, headers: Self.generateExporterHeaders(configuration.auth))
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let channel = Self.getChannel(with: configuration, group: group)
         
@@ -78,10 +76,10 @@ class OpenTelemetryInitializer {
          
     }
     
-    private static func generateExporterHeaders(_ token: String?) -> [(String, String)]? {
+    private static func generateExporterHeaders(_ auth: String?) -> [(String, String)]? {
         var headers = [(String, String)]()
-        if let t = token {
-            headers.append((Headers.authorization, "\(Headers.bearer) \(t)"))
+        if let auth = auth {
+            headers.append((Headers.authorization, "\(auth)"))
         }
         headers.append((Headers.userAgent, generateExporterUserAgent()))
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -35,4 +35,16 @@ The `AgentConfigBuilder` can be configured with the following functions
 
 Sets the secret token for connecting to an authenticated APM Server. If using the env-var, the whole header map must be defined per https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md[OpenTelemetry Protocol Exporter Config] (e.g.: `OTEL_EXPORTER_OTLP_HEADERS="Authorization=bearer <secret token>"`)
 
+This setting is mutually exclusive with `withApiKey`
+
+[discrete]
+[[withApiKey]]
+==== `withApiKey`
+* *Type:* String
+* Default:* nil
+* *Env:* `OTEL_EXPORTER_OTLP_HEADERS`
+
+Sets the API Token for connecting to an authenticated APM Server. If using the env-var, the whole header map must be defined per https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md[OpenTelemetry Protocol Exporter Config] (e.g.: `OTEL_EXPORTER_OTLP_HEADERS="Authorization=ApiKey <key>"`)
+
+This setting is mutually exclusive with `withSecretToken`
 


### PR DESCRIPTION
changed the way authorization headers are generated, and left backwards compatibility for the existing (deprecated) Agent Configuration. 