### PR TITLE
updated otel and removed references to OpenTelemetrySDK

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ashleymills/Reachability.swift", from: "5.1.0"),
-        .package(url: "https://github.com/open-telemetry/opentelemetry-swift", branch:"main"),
+        .package(url: "https://github.com/open-telemetry/opentelemetry-swift", exact:"1.4.1"),
         .package(url:"https://github.com/elastic/TrueTime.swift.git", exact: "1.0.0"),
         .package(url: "https://github.com/microsoft/plcrashreporter.git", .upToNextMajor(from: "1.0.0")),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ashleymills/Reachability.swift", from: "5.1.0"),
-        .package(url: "https://github.com/open-telemetry/opentelemetry-swift", exact: "1.3.1"),
+        .package(url: "https://github.com/open-telemetry/opentelemetry-swift", branch:"main"),
         .package(url:"https://github.com/elastic/TrueTime.swift.git", exact: "1.0.0"),
         .package(url: "https://github.com/microsoft/plcrashreporter.git", .upToNextMajor(from: "1.0.0")),
     ],

--- a/Sources/Instrumentation/CPUSampler/CPUSampler.swift
+++ b/Sources/Instrumentation/CPUSampler/CPUSampler.swift
@@ -20,7 +20,7 @@ public class CPUSampler {
     let meter: Meter
     var gauge: DoubleObserverMetric
     public init() {
-        meter = OpenTelemetrySDK.instance.meterProvider.get(instrumentationName: "CPU Sampler", instrumentationVersion: "0.0.1")
+        meter = OpenTelemetry.instance.meterProvider.get(instrumentationName: "CPU Sampler", instrumentationVersion: "0.0.1")
         gauge = meter.createDoubleObservableGauge(name: "system.cpu.usage") {
             gauge in
             gauge.observe(value: CPUSampler.cpuFootprint(), labels: ["state": "app"])

--- a/Sources/Instrumentation/MemorySampler/MemorySampler.swift
+++ b/Sources/Instrumentation/MemorySampler/MemorySampler.swift
@@ -22,7 +22,7 @@ public class MemorySampler {
     var gauge : IntObserverMetric
     
     public init() {
-        meter = OpenTelemetrySDK.instance.meterProvider.get(instrumentationName: "Memory Sampler", instrumentationVersion: "0.0.1")
+        meter = OpenTelemetry.instance.meterProvider.get(instrumentationName: "Memory Sampler", instrumentationVersion: "0.0.1")
         gauge = meter.createIntObservableGauge(name: "system.memory.usage") { gauge in
             if let memoryUsage = MemorySampler.memoryFootprint() {
                 gauge.observe(value: Int(memoryUsage), labels: ["state": "app"])

--- a/Sources/apm-agent-ios/Agent.swift
+++ b/Sources/apm-agent-ios/Agent.swift
@@ -45,8 +45,7 @@ public class Agent {
         self.configuration = configuration
         self.instrumentationConfiguration = instrumentationConfiguration
         instrumentation = InstrumentationWrapper(config: instrumentationConfiguration)
-        _ = OpenTelemetrySDK.instance // initialize sdk, or else it will over write our providers
-
+        
         group = OpenTelemetryInitializer.initialize(configuration)
 
         if instrumentationConfiguration.enableCrashReporting {

--- a/Sources/apm-agent-ios/Instrumentation/AppMetrics/AppMetrics.swift
+++ b/Sources/apm-agent-ios/Instrumentation/AppMetrics/AppMetrics.swift
@@ -60,7 +60,7 @@ class AppMetrics : NSObject, MXMetricManagerSubscriber {
         }
     }
     
-    let meter = OpenTelemetrySDK.instance.meterProvider.get(instrumentationName: instrumentation_name, instrumentationVersion: instrumentation_version)
+    let meter = OpenTelemetry.instance.meterProvider.get(instrumentationName: instrumentation_name, instrumentationVersion: instrumentation_version)
     
     func receiveReports() {
         let shared = MXMetricManager.shared

--- a/Sources/apm-agent-ios/Instrumentation/ViewController/ViewControllerInstrumentation.swift
+++ b/Sources/apm-agent-ios/Instrumentation/ViewController/ViewControllerInstrumentation.swift
@@ -82,7 +82,7 @@ internal class VCNameOverrideStore {
         }
 
         static func getTracer() -> TracerSdk {
-            OpenTelemetrySDK.instance.tracerProvider.get(instrumentationName: "UIViewController", instrumentationVersion: "0.0.2") as! TracerSdk
+            OpenTelemetry.instance.tracerProvider.get(instrumentationName: "UIViewController", instrumentationVersion: "0.0.2") as! TracerSdk
         }
 
         


### PR DESCRIPTION
OpenTelemetry-swift removed `OpenTelemetrySDK` object, which caused initialization problems, in favor of `OpenTelemetry` object.