### PR TITLE
exposes `recording` flag for local use

### DIFF
--- a/Sources/apm-agent-ios/Configuration/CentralConfig.swift
+++ b/Sources/apm-agent-ios/Configuration/CentralConfig.swift
@@ -15,8 +15,10 @@
 import Foundation
 import OpenTelemetrySdk
 
-class CentralConfig {
+public class CentralConfig {
     static let CentralConfigKey = "elastic.central.configuration"
+        
+    public init () {}
     
     public var data : CentralConfigData {
         get {
@@ -28,6 +30,12 @@ class CentralConfig {
                 }
             }
             return CentralConfigData()
+        }
+        set(data)  {
+            do {
+                config = String(data: try JSONEncoder().encode(data), encoding: .utf8)
+            } catch {}
+
         }
     }
     

--- a/Sources/apm-agent-ios/Configuration/CentralConfigData.swift
+++ b/Sources/apm-agent-ios/Configuration/CentralConfigData.swift
@@ -15,14 +15,15 @@
 import Foundation
 
 
-struct CentralConfigData : Decodable {
+public struct CentralConfigData : Codable {
     
-    public private(set) var recording : Bool = true
+    public var recording : Bool = true
     
     enum CodingKeys : String, CodingKey {
         case recording
     }
-    init(from decoder: Decoder) throws {
+     
+    public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         
         do {


### PR DESCRIPTION
this will allow single device configuration of `recording` when the central config values is not set. 