### PR TITLE
fixed inversion of 'should include' in filter

### DIFF
--- a/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
+++ b/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
@@ -49,19 +49,19 @@ class OpenTelemetryInitializer {
 
     var traceSampleFilter: [SignalFilter<ReadableSpan>] = [
       SignalFilter<ReadableSpan>({ [self] _ in
-        !self.sessionSampler.shouldSample
+        self.sessionSampler.shouldSample
       })
     ]
 
     var logSampleFliter: [SignalFilter<ReadableLogRecord>] = [
       SignalFilter<ReadableLogRecord>({ [self] _ in
-        !self.sessionSampler.shouldSample
+        self.sessionSampler.shouldSample
       })
     ]
 
     var metricSampleFilter: [SignalFilter<Metric>] = [
       SignalFilter<Metric>({ [self] _ in
-        !self.sessionSampler.shouldSample
+        self.sessionSampler.shouldSample
       })
     ]
 


### PR DESCRIPTION
The `not` operator was incorrectly applied to the signal filters resulting in signals not being sent when they ought to. 