### PR TITLE
added session id to crash reports

### DIFF
--- a/Sources/Tests/apm-agent-iosTests/SessionManagerTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/SessionManagerTests.swift
@@ -36,4 +36,14 @@ final class SessionManagerTests: XCTestCase {
 
         XCTAssertTrue(SessionManager.instance.isValid())
     }
+    
+    func testNoUpdateSessionParameter() {
+        _ = SessionManager.instance
+        let uuid = UUID()
+        UserDefaults.standard.setValue(uuid.uuidString, forKey: SessionManager.sessionIdKey)
+        UserDefaults.standard.setValue(Date.distantPast, forKey: SessionManager.sessionTimerKey)
+        
+        XCTAssertTrue(SessionManager.instance.session(false) == uuid.uuidString)
+        XCTAssertFalse(SessionManager.instance.session() == uuid.uuidString)
+    }
 }

--- a/Sources/apm-agent-ios/Agent.swift
+++ b/Sources/apm-agent-ios/Agent.swift
@@ -20,7 +20,6 @@ public class Agent {
     TrueTimeClient.sharedInstance.start()
     instance = Agent(
       configuration: configuration, instrumentationConfiguration: instrumentationConfiguration)
-    instance?.initialize()
   }
 
   public static func start() {
@@ -44,10 +43,12 @@ public class Agent {
   let openTelemetry: OpenTelemetryInitializer
 
   let sessionSampler: SessionSampler
+    
 
   private init(
     configuration: AgentConfiguration, instrumentationConfiguration: InstrumentationConfiguration
   ) {
+    let lastSessionForCrashReport = SessionManager.instance.session(false)
     _ = SessionManager.instance.session()  // initialize session
     agentConfigManager = AgentConfigManager(
       resource: AgentResource.get().merging(other: AgentEnvResource.get()), config: configuration,
@@ -76,12 +77,10 @@ public class Agent {
       crashManager = nil
     }
     os_log("Initializing Elastic APM Agent.")
-  }
-
-  private func initialize() {
+      
     instrumentation.initalize()
     if agentConfigManager.instrumentation.enableCrashReporting {
-      crashManager?.initializeCrashReporter()
+      crashManager?.initializeCrashReporter(lastSession: lastSessionForCrashReport)
     }
   }
 

--- a/Sources/apm-agent-ios/Session/SessionManager.swift
+++ b/Sources/apm-agent-ios/Session/SessionManager.swift
@@ -52,14 +52,16 @@ public class SessionManager {
     }
   }
 
-  public func session() -> String {
-    if isValid() {
-      updateTimeout()
-    } else {
-      refreshSession()
+    public func session(_ update: Bool = true) -> String {
+        if update {
+            if isValid() {
+                updateTimeout()
+            } else {
+                refreshSession()
+            }
+        }
+        return currentId.uuidString
     }
-    return currentId.uuidString
-  }
 
   public func updateTimeout() {
     lastUpdated = Date()


### PR DESCRIPTION
to ensure the session id gathered for the crash report is accurate, a mechanism to fetch the last used session id without refreshing to token if it is out of date was necessary. This will ensure that crashes that occurred before the 30minute session timeout will be attributed with the correct session id. This was accomplished by adding an optional boolean to the session getter.