### PR TITLE
Fix for NTP-related memory leak issues caused by TrueTime library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     .package(url: "https://github.com/ashleymills/Reachability.swift", from: "5.1.0"),
     .package(
       url: "https://github.com/open-telemetry/opentelemetry-swift", exact: "1.9.1"),
-    .package(url: "https://github.com/elastic/TrueTime.swift.git", exact: "1.0.0"),
+    .package(url: "https://github.com/MobileNativeFoundation/Kronos.git", .upToNextMajor(from: "4.2.2")),
     .package(
       url: "https://github.com/microsoft/plcrashreporter.git", .upToNextMajor(from: "1.0.0")),
   ],
@@ -48,7 +48,7 @@ let package = Package(
         .product(name: "URLSessionInstrumentation", package: "opentelemetry-swift"),
         .product(name: "ResourceExtension", package: "opentelemetry-swift"),
         .product(name: "Reachability", package: "Reachability.swift"),
-        .product(name: "TrueTime", package: "TrueTime.swift"),
+        .product(name: "Kronos", package: "Kronos"),
         .product(name: "CrashReporter", package: "plcrashreporter"),
         "MemorySampler",
         "CPUSampler",

--- a/Sources/apm-agent-ios/ElasticApmAgent.swift
+++ b/Sources/apm-agent-ios/ElasticApmAgent.swift
@@ -3,8 +3,8 @@ import Foundation
 import NIO
 import OpenTelemetryApi
 import OpenTelemetrySdk
-import TrueTime
 import os.log
+import Kronos
 
 public class ElasticApmAgent {
  public static let name = "apm-agent-ios"
@@ -18,7 +18,7 @@ public class ElasticApmAgent {
       return
     }
 
-    TrueTimeClient.sharedInstance.start()
+      Kronos.Clock.sync()
     instance = ElasticApmAgent(
       configuration: configuration, instrumentationConfiguration: instrumentationConfiguration)
   }

--- a/Sources/apm-agent-ios/Utils/NTPClock.swift
+++ b/Sources/apm-agent-ios/Utils/NTPClock.swift
@@ -13,17 +13,18 @@
 //   limitations under the License.
 
 import Foundation
-import OpenTelemetryApi
 import OpenTelemetrySdk
-import TrueTime
+import Kronos
 import os.log
 
-class NTPClock: Clock {
+class NTPClock: OpenTelemetrySdk.Clock {
     var now: Date {
-        if let date = TrueTimeClient.sharedInstance.referenceTime?.now() {
+        if let date = Kronos.Clock.now {
+            os_log("Using Kronos Clock.now as fallback.")
             return date
         }
-        os_log("TrueTime referenceTime unavailable. using system clock as fallback.")
+
+        os_log("Kronos Clock.now unavailable. using system clock as fallback.")
         return Date()
     }
 }


### PR DESCRIPTION
Closes #211 
- replacing TrueTime by Kronos
- sync Kronos Clock and update NTPClock class
- extra log of using Kronos time