### PR TITLE
fixed build issues with tvos and mac

### DIFF
--- a/Sources/apm-agent-ios/ElasticApmAgent.swift
+++ b/Sources/apm-agent-ios/ElasticApmAgent.swift
@@ -51,7 +51,10 @@ public class ElasticApmAgent {
     configuration: AgentConfiguration, instrumentationConfiguration: InstrumentationConfiguration
   ) {
     crashConfig.sessionId = SessionManager.instance.session(false)
-    crashConfig.networkStatus = NetworkStatusManager().lastStatus
+    #if os(iOS) && !targetEnvironment(macCatalyst)
+      crashConfig.networkStatus = NetworkStatusManager().lastStatus
+    #endif // os(iOS) && !targetEnvironment(macCatalyst)
+
     _ = SessionManager.instance.session()  // initialize session
     agentConfigManager = AgentConfigManager(
       resource: AgentResource.get().merging(other: AgentEnvResource.get()), config: configuration,

--- a/Sources/apm-agent-ios/Instrumentation/CrashReporting/CrashManager.swift
+++ b/Sources/apm-agent-ios/Instrumentation/CrashReporting/CrashManager.swift
@@ -21,6 +21,7 @@ import OpenTelemetryApi
 import OpenTelemetryProtocolExporterCommon
 import OpenTelemetryProtocolExporterGrpc
 import OpenTelemetrySdk
+
 import os.log
 
 struct CrashManager {
@@ -75,10 +76,10 @@ struct CrashManager {
     }
   }
 
-    public func initializeCrashReporter(configuration: CrashManagerConfiguration) {
+  public func initializeCrashReporter(configuration: CrashManagerConfiguration) {
     // It is strongly recommended that local symbolication only be enabled for non-release builds.
     // Use [] for release versions.
-    let config = PLCrashReporterConfig(signalHandlerType: .mach, symbolicationStrategy: [])
+    let config = PLCrashReporterConfig(signalHandlerType: getSignalHandler(), symbolicationStrategy: [])
     guard let crashReporter = PLCrashReporter(configuration: config) else {
       print("Could not create an instance of PLCrashReporter")
       return
@@ -148,6 +149,15 @@ struct CrashManager {
     crashReporter.purgePendingCrashReport()
   }
 
+  
+  private func getSignalHandler() -> PLCrashReporterSignalHandlerType {
+    #if os(tvOS)
+      return .BSD
+    #else
+      return .mach
+    #endif
+  }
+  
   private func isDebuggerAttached() -> Bool {
     var info = kinfo_proc()
     let infoSize = UnsafeMutablePointer<Int>.allocate(capacity: 1)

--- a/Sources/apm-agent-ios/Instrumentation/Lifecycle/ApplicationLifecycleInstrumentation.swift
+++ b/Sources/apm-agent-ios/Instrumentation/Lifecycle/ApplicationLifecycleInstrumentation.swift
@@ -12,6 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
+#if canImport(UIKit)
 import Foundation
 import UIKit
 import OpenTelemetryApi
@@ -95,3 +96,5 @@ public class ApplicationLifecycleInstrumentation: NSObject {
             .setAttributes(["lifecycle.state": AttributeValue.string(State.terminate.rawValue)])
             .emit()}
 }
+
+#endif

--- a/Sources/apm-agent-ios/OpenTelementry Extensions/ElasticLogRecordProcessor.swift
+++ b/Sources/apm-agent-ios/OpenTelementry Extensions/ElasticLogRecordProcessor.swift
@@ -40,8 +40,11 @@ public struct ElasticLogRecordProcessor: LogRecordProcessor {
     var attributes = logRecord.attributes
     attributes[ElasticAttributes.sessionId.rawValue] = AttributeValue.string(
       SessionManager.instance.session())
-    attributes[SemanticAttributes.networkConnectionType.rawValue] = AttributeValue
-      .string(NetworkStatusManager().status())
+    #if os(iOS) && !targetEnvironment(macCatalyst)
+      attributes[SemanticAttributes.networkConnectionType.rawValue] = AttributeValue
+        .string(NetworkStatusManager().status())
+    #endif // os(iOS) && !targetEnvironment(macCatalyst)
+
 
     let appendedLogRecord = ReadableLogRecord(
       resource: logRecord.resource,

--- a/Sources/apm-agent-ios/Utils/NetworkStatusManager.swift
+++ b/Sources/apm-agent-ios/Utils/NetworkStatusManager.swift
@@ -12,6 +12,9 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
+
+#if os(iOS) && !targetEnvironment(macCatalyst)
+
 import Foundation
 import NetworkStatus
 
@@ -52,3 +55,5 @@ class NetworkStatusManager {
     return status
   }
 }
+
+#endif // os(iOS) && !targetEnvironment(macCatalyst)


### PR DESCRIPTION
I added conditionals for all references to `NetworkStatus` which is only available for iOS based apps, and not available in mac catalyst (iOS apps on mac). This change is inline with the way opentelemetry-swift also includes this component. 

additional issues corrected:
**tvos** : `mach` signal handler is not available on tvos, so `bsd` type is used instead. 
**Lifecycle instrumentation** : only include the lifecycle instrumentation if UIKit is available. This may be extended for AppKit if there is interest. 

Fixes #221 