### PR TITLE
github-actions: run release step when tag release and support attest

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,6 +13,10 @@ permissions:
 jobs:
   macos:
     runs-on: macos-12
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
@@ -34,3 +38,10 @@ jobs:
         path: |
           .ci/snapshoty.yml
           dist/**
+
+    - name: generate build provenance
+      # If no PR event or if a PR event that's caused by a non-fork and non dependabot actor
+      if: github.event_name != 'pull_request' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' )
+      uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d  # v1.1.2
+      with:
+        subject-path: "${{ github.workspace }}/dist/**"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,6 @@ jobs:
           echo "INFO: Create '$GITHUB_REF_NAME' GitHub release (latest=$IS_LATEST)."
           gh release create "$GITHUB_REF_NAME" \
             --title "$GITHUB_REF_NAME" \
-            --notes-file "$RELEASE_NOTES_FILE" \
             --latest=$IS_LATEST \
             ./dist/*
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: macos
+
+on:
+  push:
+    tags:
+      - v*.*.*
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  cocoapods:
+    runs-on: macos-12
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+    # If no PR event or if a PR event that's caused by a non-fork and non dependabot actor
+    if: github.event_name != 'pull_request' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' )
+    steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '14.0'
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run build
+        run: .ci/scripts/build.sh
+
+      - name: Run package snapshots
+        run: .ci/scripts/package.sh
+
+      - name: Generate build provenance
+        uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d  # v1.1.2
+        with:
+          subject-path: "${{ github.workspace }}/**/*"
+
+      - name: Create github release (only for tag release)
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          readonly LATEST_GIT_TAG=$(git tag --list --sort=version:refname "v*" | grep -v - | tail -n1)
+          if [[ "$GITHUB_REF_NAME" == "$LATEST_GIT_TAG" ]]; then
+            IS_LATEST=true
+          else
+            IS_LATEST=false
+          fi
+          echo "INFO: Create '$GITHUB_REF_NAME' GitHub release (latest=$IS_LATEST)."
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file "$RELEASE_NOTES_FILE" \
+            --latest=$IS_LATEST \
+            ./dist/*
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Generate build provenance
         uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d  # v1.1.2
         with:
-          subject-path: "${{ github.workspace }}/**/*"
+          subject-path: "${{ github.workspace }}/dist/*"
 
       - name: Create github release (only for tag release)
         if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-12
     permissions:
       attestations: write
-      contents: read
+      contents: write
       id-token: write
     # If no PR event or if a PR event that's caused by a non-fork and non dependabot actor
     if: github.event_name != 'pull_request' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
       attestations: write
       contents: write
       id-token: write
-    # If no PR event or if a PR event that's caused by a non-fork and non dependabot actor
-    if: github.event_name != 'pull_request' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' )
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:


### PR DESCRIPTION
This should help to store artifacts in the GitHub releases and also attest those binaries.

I used partially what the apm-agent-nodejs does with the GitHub releases in https://github.com/elastic/apm-agent-nodejs/blob/main/dev-utils/github-release.sh

@bryce-b, I think you can now change this PR to call the script in charge of generating the binaries and then modify:

- `subject-path`
- `Create github release`

To include what files should be attested and also what files should archived when there is a release.
