### PR TITLE
updated purpuse of collected data from Analytics to App Functionality

### DIFF
--- a/Sources/apm-agent-ios/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/apm-agent-ios/Resources/PrivacyInfo.xcprivacy
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPrivacyTrackingDomains</key>
-	<array>
-		<string></string>
-	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>
 	<key>NSPrivacyCollectedDataTypes</key>

--- a/Sources/apm-agent-ios/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/apm-agent-ios/Resources/PrivacyInfo.xcprivacy
@@ -19,7 +19,7 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
 			</array>
 		</dict>
 		<dict>
@@ -31,7 +31,7 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
 			</array>
 		</dict>
 		<dict>
@@ -43,7 +43,7 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
 			</array>
 		</dict>
 		<dict>
@@ -55,7 +55,7 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
Added updated purposes, and removed tracking domains field. The domains field is not required because we are not 'tracking' per the definitions provided by Apple: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files