### PR TITLE
Set connection type in the AgentConfigBuilder

### DIFF
--- a/Sources/apm-agent-ios/AgentConfigBuilder.swift
+++ b/Sources/apm-agent-ios/AgentConfigBuilder.swift
@@ -81,6 +81,7 @@ public class AgentConfigBuilder {
     config.logFilters = logFilters
     config.spanFilters = spanFilters
     config.metricFilters = metricFilters
+    config.connectionType = connectionType
 
     if let url = url {
       if let proto = url.scheme, proto == "https" {


### PR DESCRIPTION
Support for HTTP connection type was added in https://github.com/elastic/apm-agent-ios/pull/228 but the `AgentConfigBuilder` doesn't set the connection type from `useConnectionType(_:)` in the `build()` method. 