### PR TITLE
github-actions: use GH app to manage the projects

### DIFF
--- a/.github/workflows/addToProject.yml
+++ b/.github/workflows/addToProject.yml
@@ -3,9 +3,6 @@ name: Auto Assign to Project(s)
 on:
   issues:
     types: [opened, edited, milestoned]
-env:
-  MY_GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
-
 permissions:
   contents: read
 
@@ -14,6 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     name: Assign milestoned to Project
     steps:
+    - name: Get token
+      id: get_token
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      with:
+        app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+        private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+        permissions: >-
+          {
+            "repository_projects": "write"
+          }
     - name: Assign issues with milestones to project
       uses: elastic/assign-one-project-github-action@1.2.2
       if: github.event.issue && github.event.issue.milestone
@@ -21,3 +28,5 @@ jobs:
         project: 'https://github.com/orgs/elastic/projects/454'
         project_id: '5882982'
         column_name: 'Planned'
+      env:
+        MY_GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}

--- a/.github/workflows/addToProject.yml
+++ b/.github/workflows/addToProject.yml
@@ -19,7 +19,8 @@ jobs:
         private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
         permissions: >-
           {
-            "repository_projects": "write"
+            "organization_projects": "write",
+            "issues": "read"
           }
     - name: Assign issues with milestones to project
       uses: elastic/assign-one-project-github-action@1.2.2

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -23,7 +23,8 @@ jobs:
         permissions: >-
           {
             "members": "read",
-            "repository_projects": "write"
+            "organization_projects": "write",
+            "issues": "read"
           }
     - name: Add agent-ios and agent-mobile labels
       uses: AlexanderWert/issue-labeler@v2.3

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,8 +4,6 @@ on:
     types: [opened]
   pull_request_target:
     types: [opened]
-env:
-  MY_GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
 
 permissions:
   contents: read
@@ -16,6 +14,17 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
+    - name: Get token
+      id: get_token
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      with:
+        app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+        private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+        permissions: >-
+          {
+            "members": "read",
+            "repository_projects": "write"
+          }
     - name: Add agent-ios and agent-mobile labels
       uses: AlexanderWert/issue-labeler@v2.3
       with:
@@ -29,10 +38,11 @@ jobs:
         username: ${{ github.actor }}
         team: 'apm'
         usernamesToExclude: |
-          apmmachine
           dependabot
           dependabot[bot]
-        GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+          elastic-observability-automation
+          elastic-observability-automation[bot]
+        GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
     - name: Show team membership
       run: |
         echo "::debug::isTeamMember: ${{ steps.checkUserMember.outputs.isTeamMember }}"
@@ -51,3 +61,5 @@ jobs:
         project: 'https://github.com/orgs/elastic/projects/454'
         project_id: '5882982'
         column_name: 'In Progress'
+      env:
+        MY_GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
### What

Use https://github.com/tibdex/github-app-token to generate ephemeral tokens with the required
permissions only

This is the alternative to moving away from finer-grained GitHub tokens and reducing the
cumbersome of rotating them as we do nowadays.

### Implementation details

We have used the same GitHub action in other places.
