### PR TITLE
ci: use macos-13

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   macos:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '14.0'
+        xcode-version: '15.2.0'
     - uses: actions/checkout@v4
 
     - name: Run build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,11 +12,11 @@ permissions:
 
 jobs:
   macos:
-    runs-on: macos-14
+    runs-on: macos-13
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '14.3.1'
+        xcode-version: '14.0'
     - uses: actions/checkout@v4
 
     - name: Run build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   macos:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '14.0'
+        xcode-version: '14.3.1'
     - uses: actions/checkout@v4
 
     - name: Run build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   macos:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,7 +23,7 @@ jobs:
       run: .ci/scripts/build.sh
 
     - name: Run test
-      run: xcodebuild -scheme apm-agent-ios-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 8' test
+      run: xcodebuild -scheme apm-agent-ios-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' test
 
     - name: Run package snapshots
       run: .ci/scripts/package.sh


### PR DESCRIPTION
> the macOS 12 runner image will be removed by December 3rd, 2024

I guess we can use `latest` as we normally are using the latest OS version

Version `14.0` is not available anymore.

> Switching Xcode to version '14.0'...
Available versions:
┌─────────┬──────────┬─────────────┬─────────────┬────────┬───────────────────────────────────────┐
│ (index) │ version  │ buildNumber │ releaseType │ stable │ path                                  │
├─────────┼──────────┼─────────────┼─────────────┼────────┼───────────────────────────────────────┤
│ 0       │ '16.1.0' │ '16B[5](https://github.com/elastic/apm-agent-ios/actions/runs/11381626412/job/31663431612?pr=238#step:2:6)014f'  │ 'Beta'      │ false  │ '/Applications/Xcode_1[6](https://github.com/elastic/apm-agent-ios/actions/runs/11381626412/job/31663431612?pr=238#step:2:7).1_beta_2.app' │
│ 1       │ '16.0.0' │ '16A242d'   │ 'GM'        │ true   │ '/Applications/Xcode_16.app'          │
│ 2       │ '15.4.0' │ '15F31d'    │ 'GM'        │ true   │ '/Applications/Xcode_15.4.app'        │
│ 3       │ '15.3.0' │ '15E204a'   │ 'GM'        │ true   │ '/Applications/Xcode_15.3.app'        │
│ 4       │ '15.2.0' │ '15C500b'   │ 'GM'        │ true   │ '/Applications/Xcode_15.2.app'        │
│ 5       │ '15.1.0' │ '15C65'     │ 'GM'        │ true   │ '/Applications/Xcode_15.1.app'        │
│ 6       │ '15.0.1' │ '15A50[7](https://github.com/elastic/apm-agent-ios/actions/runs/11381626412/job/31663431612?pr=238#step:2:8)'    │ 'GM'        │ true   │ '/Applications/Xcode_15.0.1.app'      │
│ 7       │ '14.3.1' │ '14E300c'   │ 'GM'        │ true   │ '/Applications/Xcode_14.3.1.app'      │
└─────────┴──────────┴─────────────┴─────────────┴────────┴───────────────────────────────────────┘
