### PR TITLE
fix: http connection type

### DIFF
--- a/Sources/apm-agent-ios/AgentConfigBuilder.swift
+++ b/Sources/apm-agent-ios/AgentConfigBuilder.swift
@@ -49,7 +49,7 @@ public class AgentConfigBuilder {
     self.connectionType = type
     return self
   }
-  
+
   public func withApiKey(_ key: String) -> Self {
     self.auth = "\(Self.api) \(key)"
     return self
@@ -81,6 +81,7 @@ public class AgentConfigBuilder {
     config.logFilters = logFilters
     config.spanFilters = spanFilters
     config.metricFilters = metricFilters
+    config.connectionType = connectionType
 
     if let url = url {
       if let proto = url.scheme, proto == "https" {

--- a/Sources/apm-agent-ios/Utils/OpenTelemetryHelper.swift
+++ b/Sources/apm-agent-ios/Utils/OpenTelemetryHelper.swift
@@ -49,16 +49,16 @@ public class OpenTelemetryHelper {
     }
 
   public static func getURL(with config: AgentConfiguration) -> URL? {
-  
+
     var port = "\(config.collectorPort)"
     if config.collectorPort == 80 || config.collectorPort == 443 {
       port = ""
     }
-    
-    return URL(string: "(\(config.collectorTLS ? "https://" : "http://")\(config.collectorHost)\( port.isEmpty ? "" : ":\(port)")")
-    
+
+    return URL(string: "\(config.collectorTLS ? "https://" : "http://")\(config.collectorHost)\( port.isEmpty ? "" : ":\(port)")")
+
   }
-  
+
     public static func getChannel(with config: AgentConfiguration, group: EventLoopGroup) -> ClientConnection {
 
         if config.collectorTLS {


### PR DESCRIPTION
Super seeding @kylemay-gridstone PR

- Support for HTTP connection type was added in #228 but the AgentConfigBuilder doesn't set the connection type from useConnectionType(_:) in the build() method.
- Fixes issue with OpenTelemetryHelper getURL method by removing extraneous "("
- Fixes issue in OpenTelemetryInitializer initializeWithHttp method which does not configure the correct endpoints using "/v1/" for grpc compatibility