### PR TITLE
[docs] Add a note about Elastic Cloud Serverless support

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -3,6 +3,11 @@
 
 The Elastic APM iOS Agent measures the performance of your mobile applications in real-time.
 
+[NOTE]
+====
+The Elastic APM iOS Agent is not compatible with {serverless-docs}[{serverless-full}].
+====
+
 [float]
 [[how-it-works]]
 === How does the agent work?


### PR DESCRIPTION
Related to https://github.com/elastic/observability-docs/issues/3394

Adds a note that lets users know that the agent is not compatible with [Elastic Cloud Serverless](https://www.elastic.co/guide/en/serverless/current/intro.html).

Note: When this PR is finalized, I'll open a PR targeting `1.x`.

cc @chrisdistasio 