### PR TITLE
CrashExporter doesn't respect connection type setting

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/ashleymills/Reachability.swift", from: "5.2.4"),
     .package(
-      url: "https://github.com/open-telemetry/opentelemetry-swift", exact: "1.12.1"),
+      url: "https://github.com/open-telemetry/opentelemetry-swift", exact: "1.13.0"),
     .package(url: "https://github.com/MobileNativeFoundation/Kronos.git", .upToNextMajor(from: "4.2.2")),
     .package(
       url: "https://github.com/microsoft/plcrashreporter.git", .upToNextMajor(from: "1.0.0")),

--- a/Sources/apm-agent-ios/Instrumentation/CrashReporting/CrashManager.swift
+++ b/Sources/apm-agent-ios/Instrumentation/CrashReporting/CrashManager.swift
@@ -14,13 +14,8 @@
 
 import CrashReporter
 import Foundation
-import GRPC
 import Logging
-import NIO
 import OpenTelemetryApi
-import OpenTelemetryProtocolExporterCommon
-import OpenTelemetryProtocolExporterGrpc
-import OpenTelemetryProtocolExporterHttp
 import OpenTelemetrySdk
 
 import os.log

--- a/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
+++ b/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
@@ -51,7 +51,7 @@ class OpenTelemetryInitializer {
   }
 
   // swiftlint:disable:next function_body_length
-  func initialize(_ configuration: AgentConfigManager) {
+  func initialize(_ configuration: AgentConfigManager) -> LogRecordExporter {
 
     var traceSampleFilter: [SignalFilter<ReadableSpan>] = [
       SignalFilter<ReadableSpan>({ [self] _ in
@@ -155,13 +155,15 @@ class OpenTelemetryInitializer {
             logSampleFliter)
         ])
         .build())
+
+    return logExporter
   }
 
 
-  func initializeWithHttp(_ configuration: AgentConfigManager) {
+  func initializeWithHttp(_ configuration: AgentConfigManager) -> LogRecordExporter {
     guard let endpoint =  OpenTelemetryHelper.getURL(with: configuration.agent) else {
       os_log("Failed to start Elastic agent: invalid collector url.")
-      return
+      return NoopLogRecordExporter.instance
     }
 
     var traceSampleFilter: [SignalFilter<ReadableSpan>] = [
@@ -262,5 +264,6 @@ class OpenTelemetryInitializer {
             logSampleFliter)
         ])
         .build())
+    return logExporter
   }
 }


### PR DESCRIPTION
This PR refactors the CrashManager to use the exporter that is initialized during the OpenTelemetry initialization phase, whether it is GRPC or HTTP. 

