### PR TITLE
Release notes: Change Heading to H2

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -31,7 +31,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 ### Fixes [elastic-apm-ios-agent-101-fixes]
 * fixed memory leaks related to NTP usage [#212]
 
-# 1.0.0 [elastic-apm-ios-agent-100-release-notes]
+## 1.0.0 [elastic-apm-ios-agent-100-release-notes]
 
 ### Features and enhancements [elastic-apm-ios-agent-100-features-enhancements]
 * Added network status to all signals [#202]


### PR DESCRIPTION
Change `1.0.0` heading to `h2` as the current rendered html looks malformed.
Also, because the "On this page" toc only shows level 2 and 3 headers, it's missing.

![image](https://github.com/user-attachments/assets/49d5a201-dc14-40ee-9667-c68a1a651117)
