### PR TITLE
[docs] Fix image paths for docs-assembler

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -186,7 +186,7 @@ In v0.5.0, the agent provides a means to set [resource attributes](https://githu
 Deployment environment is set to `default`. This can be overridden using the `OTEL_RESOURCE_ATTRIBUTES` set in your deployment’s plist. Use the field key as `OTEL_RESOURCE_ATTRIBUTES` and the value as `deployment.environment=staging`
 
 
-### Dynamic configuration ![dynamic config](/reference/images/dynamic-config.svg "") [dynamic-configuration]
+### Dynamic configuration ![dynamic config](images/dynamic-config.svg "") [dynamic-configuration]
 
 Dynamic configurations are available through the kibana UI and are read by the agent remotely to apply configuration on all active agents deployed in the field. More info on dynamic configurations can be found in  [agent configurations](docs-content://solutions/observability/apps/apm-agent-central-configuration.md).
 
@@ -197,7 +197,7 @@ A boolean specifying if the agent should be recording or not. When recording, th
 
 You can set this setting to dynamically disable Elastic APM at runtime
 
-![dynamic config](/reference/images/dynamic-config.svg "")
+![dynamic config](images/dynamic-config.svg "")
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -212,7 +212,7 @@ This session focused sampling technique is to preserve related data points, as o
 
 You can set this value dynamically at runtime.
 
-![dynamic config](/reference/images/dynamic-config.svg "")
+![dynamic config](images/dynamic-config.svg "")
 
 | Default | Type | Dynamic |
 | --- | --- | --- |


### PR DESCRIPTION
Fixes image paths to work with docs-assembler.

Notes for the reviewer:
* I was not able to get images in reference, extend, or release-notes to work using the `:::{image}` syntax because it seems to resolve differently than the Markdown `![]()` syntax. We should address this in docs-builder, but in order to get images working as soon as possible, I've used Markdown syntax and left us a `TO DO` in a code comment to add back the `screenshot` class where applicable. 
* Can you please add the appropriate labels needed for backporting? 