### PR TITLE
Allow signal filters to be mutable

### DIFF
--- a/Sources/apm-agent-ios/AgentConfigBuilder.swift
+++ b/Sources/apm-agent-ios/AgentConfigBuilder.swift
@@ -80,16 +80,16 @@ public class AgentConfigBuilder {
     return self
   }
 
-  public func addSpanFilter(_ shouldInclude: @escaping (ReadableSpan) -> Bool) -> Self {
+  public func addSpanFilter(_ shouldInclude: @escaping (inout any ReadableSpan) -> Bool) -> Self {
     spanFilters.append(SignalFilter<ReadableSpan>(shouldInclude))
     return self
   }
-  public func addMetricFilter(_ shouldInclude: @escaping (Metric) -> Bool) -> Self {
+  public func addMetricFilter(_ shouldInclude: @escaping (inout Metric) -> Bool) -> Self {
     metricFilters.append(SignalFilter<Metric>(shouldInclude))
     return self
   }
 
-  public func addLogFilter(_ shouldInclude: @escaping (ReadableLogRecord) -> Bool) -> Self {
+  public func addLogFilter(_ shouldInclude: @escaping (inout ReadableLogRecord) -> Bool) -> Self {
     logFilters.append(SignalFilter<ReadableLogRecord>(shouldInclude))
     return self
   }

--- a/Sources/apm-agent-ios/OpenTelementry Extensions/ElasticLogRecordProcessor.swift
+++ b/Sources/apm-agent-ios/OpenTelementry Extensions/ElasticLogRecordProcessor.swift
@@ -46,7 +46,7 @@ public struct ElasticLogRecordProcessor: LogRecordProcessor {
     #endif // os(iOS) && !targetEnvironment(macCatalyst)
 
 
-    let appendedLogRecord = ReadableLogRecord(
+    var appendedLogRecord = ReadableLogRecord(
       resource: logRecord.resource,
       instrumentationScopeInfo: logRecord.instrumentationScopeInfo,
       timestamp: logRecord.timestamp,
@@ -56,7 +56,8 @@ public struct ElasticLogRecordProcessor: LogRecordProcessor {
       body: logRecord.body,
       attributes: attributes)
 
-      for filter in filters where !filter.shouldInclude(appendedLogRecord) {
+
+      for filter in filters where !filter.shouldInclude(&appendedLogRecord) {
         return
       }
 

--- a/Sources/apm-agent-ios/OpenTelementry Extensions/ElasticMetricProcessor.swift
+++ b/Sources/apm-agent-ios/OpenTelementry Extensions/ElasticMetricProcessor.swift
@@ -58,10 +58,12 @@ public class ElasticMetricProcessor: MetricProcessor {
       return
     }
 
-    for filter in filters where !filter.shouldInclude(metric) {
+    var mutableMetric = metric
+
+    for filter in filters where !filter.shouldInclude(&mutableMetric) {
       return
     }
 
-    metrics.append(metric)
+    metrics.append(mutableMetric)
   }
 }

--- a/Sources/apm-agent-ios/OpenTelementry Extensions/SignalFilter.swift
+++ b/Sources/apm-agent-ios/OpenTelementry Extensions/SignalFilter.swift
@@ -15,9 +15,9 @@
 import Foundation
 
 public struct SignalFilter<Signal> {
-    public private(set) var shouldInclude: (Signal) -> Bool
+    public private(set) var shouldInclude: (inout Signal) -> Bool
 
-    init(_ shouldInclude: @escaping (Signal) -> Bool) {
+    init(_ shouldInclude: @escaping (inout Signal) -> Bool) {
         self.shouldInclude = shouldInclude
     }
 }

--- a/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
+++ b/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
@@ -166,8 +166,8 @@ class OpenTelemetryInitializer {
       return NoopLogRecordExporter.instance
     }
 
-    var traceSampleFilter: [SignalFilter<ReadableSpan>] = [
-      SignalFilter<ReadableSpan>({ [self] _ in
+    var traceSampleFilter: [SignalFilter<any ReadableSpan>] = [
+      SignalFilter<any ReadableSpan>({ [self] _ in
         self.sessionSampler.shouldSample
       })
     ]


### PR DESCRIPTION
closes https://github.com/elastic/apm-agent-ios/issues/265
This will facility a way to add attributes global with existing interfaces.