### PR TITLE
add ability to add collector path prefix

### DIFF
--- a/Sources/apm-agent-ios/AgentConfigBuilder.swift
+++ b/Sources/apm-agent-ios/AgentConfigBuilder.swift
@@ -23,6 +23,7 @@ public class AgentConfigBuilder {
   private var managementUrl: URL?
   private var enableRemoteManagement: Bool = true
   private var auth: String?
+  private var collectorPathPrefix: String?
   private static let bearer = "Bearer"
   private static let api = "ApiKey"
   private var connectionType : AgentConnectionType = .grpc
@@ -94,6 +95,12 @@ public class AgentConfigBuilder {
     return self
   }
 
+  ///  prefix needs to start with '/'
+  public func addCollectorPathPrefix(_ prefix: String) -> Self {
+    self.collectorPathPrefix = prefix
+    return self
+  }
+
   public func build() -> AgentConfiguration {
 
     var config = AgentConfiguration()
@@ -104,6 +111,7 @@ public class AgentConfigBuilder {
     config.connectionType = connectionType
     config.managementUrl = self.managementUrl
     config.enableRemoteManagement = enableRemoteManagement
+    config.collectorPathPrefix = collectorPathPrefix
 
     let url = self.exportUrl ?? self.url
     if let url {

--- a/Sources/apm-agent-ios/AgentConfiguration.swift
+++ b/Sources/apm-agent-ios/AgentConfiguration.swift
@@ -16,6 +16,7 @@ public struct AgentConfiguration {
   public var collectorHost = "127.0.0.1"
   public var collectorPort = 8200
   public var collectorTLS = false
+  public var collectorPathPrefix: String?
   public var connectionType : AgentConnectionType = .grpc
   var auth: String?
   var sampleRate: Double = 1.0
@@ -41,7 +42,8 @@ public struct AgentConfiguration {
       }
       components.host = collectorHost
       components.port = collectorPort
-      components.path = "/config/v1/agents"
+      let pathPrefix = collectorPathPrefix ?? ""
+      components.path =  pathPrefix + "/config/v1/agents"
       return components
     }
   }

--- a/Sources/apm-agent-ios/Utils/OpenTelemetryHelper.swift
+++ b/Sources/apm-agent-ios/Utils/OpenTelemetryHelper.swift
@@ -56,7 +56,7 @@ public class OpenTelemetryHelper {
     }
 
     return URL(string: "\(config.collectorTLS ? "https://" : "http://")\(config.collectorHost)\( port.isEmpty ? "" : ":\(port)")")
-
+    return URL(string: "\(config.collectorTLS ? "https://" : "http://")\(config.collectorHost)\( port.isEmpty ? "" : ":\(port)")\(config.collectorPathPrefix ?? "")")
   }
 
     public static func getChannel(with config: AgentConfiguration, group: EventLoopGroup) -> ClientConnection {


### PR DESCRIPTION
We had the issue, that our installation was pointing to a different path for the export url, so that needed to be reflected in the  OpenTelemetryHelper