### PR TITLE
clean up dependencies and supported platform version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-//swift-tools-version: 5.7
+//swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,10 +6,10 @@ import PackageDescription
 let package = Package(
   name: "apm-agent-ios",
   platforms: [
-    .iOS(.v13),
-    .macOS(.v10_15),
-    .tvOS(.v13),
-    .watchOS(.v4),
+    .iOS(.v16),
+    .macOS(.v13),
+    .tvOS(.v16),
+    .watchOS(.v10),
   ],
   products: [
     // Products define the executables and libraries a package produces, and make them visible to other package.
@@ -23,7 +23,7 @@ let package = Package(
       url: "https://github.com/open-telemetry/opentelemetry-swift", exact: "1.16.0"),
     .package(url: "https://github.com/MobileNativeFoundation/Kronos.git", .upToNextMajor(from: "4.2.2")),
     .package(
-      url: "https://github.com/microsoft/plcrashreporter.git", .upToNextMajor(from: "1.0.0")),
+      url: "https://github.com/microsoft/plcrashreporter.git", .upToNextMajor(from: "1.12.0")),
   ],
   targets: [
     .target(
@@ -48,9 +48,21 @@ let package = Package(
         .product(name: "PersistenceExporter", package: "opentelemetry-swift"),
         .product(name: "URLSessionInstrumentation", package: "opentelemetry-swift"),
         .product(name: "ResourceExtension", package: "opentelemetry-swift"),
-        .product(name: "Reachability", package: "Reachability.swift"),
-        .product(name: "Kronos", package: "Kronos"),
-        .product(name: "CrashReporter", package: "plcrashreporter"),
+        .product(
+          name: "Reachability",
+          package: "Reachability.swift",
+          condition: .when(platforms: [.macOS, .iOS, .tvOS])
+        ),
+        .product(
+          name: "Kronos",
+          package: "Kronos",
+          condition: .when(platforms: [.macOS, .iOS, .tvOS])
+        ),
+        .product(
+          name: "CrashReporter",
+          package: "plcrashreporter",
+          condition: .when(platforms: [.macOS, .iOS, .tvOS])
+        ),
         "MemorySampler",
         "CPUSampler",
       ],

--- a/Sources/apm-agent-ios/ElasticApmAgent.swift
+++ b/Sources/apm-agent-ios/ElasticApmAgent.swift
@@ -1,10 +1,12 @@
+#if !os(watchOS)
 import CrashReporter
+import Kronos
+#endif
 import Foundation
 import NIO
 import OpenTelemetryApi
 import OpenTelemetrySdk
 import os.log
-import Kronos
 
 public class ElasticApmAgent {
  public static let name = "apm-agent-ios"
@@ -17,8 +19,10 @@ public class ElasticApmAgent {
       os_log("Elastic APM Agent has been disabled.")
       return
     }
+    #if !os(watchOS)
+    Kronos.Clock.sync()
+    #endif
 
-      Kronos.Clock.sync()
     instance = ElasticApmAgent(
       configuration: configuration, instrumentationConfiguration: instrumentationConfiguration)
   }
@@ -37,8 +41,10 @@ public class ElasticApmAgent {
 
   let instrumentation: InstrumentationWrapper
 
+  #if !os(watchOS)
   let crashManager: CrashManager?
-
+  #endif
+  
   let crashLogExporter: LogRecordExporter
 
   let agentConfigManager: AgentConfigManager
@@ -82,7 +88,7 @@ public class ElasticApmAgent {
       }
 
 
-
+    #if !os(watchOS)
     if instrumentationConfiguration.enableCrashReporting {
       crashManager = CrashManager(
         resource: AgentResource.get().merging(other: AgentEnvResource.get()),
@@ -90,12 +96,17 @@ public class ElasticApmAgent {
     } else {
       crashManager = nil
     }
+    #endif
+
     os_log("Initializing Elastic APM Agent.")
 
     instrumentation.initalize()
+
+    #if !os(watchOS)
     if agentConfigManager.instrumentation.enableCrashReporting {
       crashManager?.initializeCrashReporter(configuration: crashConfig)
     }
+    #endif
   }
 
   deinit {

--- a/Sources/apm-agent-ios/Instrumentation/AppMetrics/AppMetrics.swift
+++ b/Sources/apm-agent-ios/Instrumentation/AppMetrics/AppMetrics.swift
@@ -13,9 +13,12 @@
 //   limitations under the License.
 
 import Foundation
-import MetricKit
 import OpenTelemetryApi
 import OpenTelemetrySdk
+
+#if !os(watchOS)
+import MetricKit
+#endif
 
 #if os(iOS)
 

--- a/Sources/apm-agent-ios/Instrumentation/CrashReporting/CrashManager.swift
+++ b/Sources/apm-agent-ios/Instrumentation/CrashReporting/CrashManager.swift
@@ -12,7 +12,9 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
+#if !os(watchOS)
 import CrashReporter
+#endif
 import Foundation
 import Logging
 import OpenTelemetryApi
@@ -20,6 +22,7 @@ import OpenTelemetrySdk
 
 import os.log
 
+#if !os(watchOS)
 struct CrashManager {
   static let crashEventName: String = "crash"
   static let crashManagerVersion = "0.0.3"
@@ -177,3 +180,5 @@ struct CrashManager {
     return false
   }
 }
+
+#endif // !os(watchOS)

--- a/Sources/apm-agent-ios/Instrumentation/Lifecycle/ApplicationLifecycleInstrumentation.swift
+++ b/Sources/apm-agent-ios/Instrumentation/Lifecycle/ApplicationLifecycleInstrumentation.swift
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import Foundation
 import UIKit
 import OpenTelemetryApi

--- a/Sources/apm-agent-ios/Utils/NTPClock.swift
+++ b/Sources/apm-agent-ios/Utils/NTPClock.swift
@@ -14,9 +14,10 @@
 
 import Foundation
 import OpenTelemetrySdk
-import Kronos
 import os.log
-
+#if !os(watchOS)
+import Kronos
+#endif
 
 class SuccessLogOnce {
   static let run: Void = {
@@ -36,11 +37,13 @@ class FailureLogOnce {
 
 class NTPClock: OpenTelemetrySdk.Clock {
   var now: Date {
+    #if !os(watchOS)
     if let date = Kronos.Clock.now {
       SuccessLogOnce.run
       return date
     }
     FailureLogOnce.run
+    #endif
     return Date()
   }
 }


### PR DESCRIPTION
There are several dependencies in the agent that are not supported by watchOS which this agent claims to support. This PR fixes that, as well as updates the supported versions to match more modern usage.