### PR TITLE
[DOCS] Fix links in release notes

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -34,17 +34,18 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 ### Features and enhancements [elastic-apm-ios-agent-102-features-enhancements]
 
-* Added Privacy Manifest file [#217].
+* Added Privacy Manifest file [#217](https://github.com/elastic/apm-agent-ios/pull/217).
 
 ## 1.0.1 [elastic-apm-ios-agent-101-release-notes]
 
 ### Fixes [elastic-apm-ios-agent-101-fixes]
 
-* Fixed memory leaks related to NTP usage [#212].
+* Fixed memory leaks related to NTP usage [#212](https://github.com/elastic/apm-agent-ios/pull/212).
 
 ## 1.0.0 [elastic-apm-ios-agent-100-release-notes]
 
 ### Features and enhancements [elastic-apm-ios-agent-100-features-enhancements]
 
-* Added network status to all signals [#202].
+* Added network status to all signals [#202](https://github.com/elastic/apm-agent-ios/pull/202).
 * Added session.id to crash reports [#195].
+  % TBD Incorrect number?


### PR DESCRIPTION
The links in https://www.elastic.co/docs/release-notes/edot/sdks/ios are currently not valid.
This PR adds the missing URLs.

I was unable to find a PR that matched "Added session.id to crash reports [#195]" but it is perhaps related to https://github.com/elastic/apm-agent-ios/issues/192