### PR TITLE
added 'useOpAMP' API documentation and expanded 'withManagementUrl'

### DIFF
--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -260,8 +260,6 @@ You can set this value dynamically at runtime.
 ## Central configuration (EDOT)
 
 ```{applies_to}
-serverless: unavailable
-stack: preview 9.2
 product:
   edot_ios: preview 1.4.0
 ```


### PR DESCRIPTION
This adds documentation around configuring the agent to use OpAMP. 

Additionally, some typographical errors were corrected. 

Fixes https://github.com/elastic/apm-agent-ios/issues/295

Contributes to Contributes to https://github.com/elastic/opentelemetry-dev/issues/992