### PR TITLE
ci: support snyk for untrusted PRs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,9 +11,6 @@ permissions:
   contents: read
 
 jobs:
-  scan-snyk:
-    uses: ./.github/workflows/scan-snyk.yml
-    secrets: inherit
   macos:
     runs-on: macos-15-large
     steps:

--- a/.github/workflows/scan-snyk.yml
+++ b/.github/workflows/scan-snyk.yml
@@ -18,6 +18,9 @@ on:
     workflows: [macos]
     types: [completed]
     branches: [main]
+  pull_request_target:
+    types: [labeled]
+    branches: [main]
 
 permissions:
   contents: read
@@ -41,12 +44,16 @@ jobs:
     #   1. The triggering workflow completed successfully
     #   2. The PR originates from the main repository (not a fork)
     #   3. We use immutable commit SHA to prevent TOCTOU attacks
+    # - pull_request with 'safe-to-run' label: reviewer approves PR for scanning
     if: |
       github.event_name == 'workflow_dispatch' || (
         github.event_name == 'workflow_run' &&
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.head_repository != null &&
         github.event.workflow_run.head_repository.full_name == github.repository
+      ) || (
+        github.event_name == 'pull_request_target' &&
+        contains(github.event.pull_request.labels.*.name, 'safe-to-run')
       )
     steps:
       - name: Validate security context
@@ -60,15 +67,25 @@ jobs:
             fi
             echo "Security: Using immutable commit SHA from workflow_run context"
             echo "Commit: ${{ github.event.workflow_run.head_commit.sha }}"
+          elif [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            # For pull_request_target: verify safe-to-run label is present
+            if ! grep -q "safe-to-run" <<< "${{ join(github.event.pull_request.labels.*.name) }}"; then
+              echo "Security Error: Pull request does not have 'safe-to-run' label"
+              exit 1
+            fi
+            echo "Security: Pull request labeled 'safe-to-run' - using immutable commit SHA"
+            echo "Commit: ${{ github.event.pull_request.head.sha }}"
           else
             echo "Security: Manual trigger - proceeding with secret access"
           fi
 
       - uses: actions/checkout@v6
         with:
-          # Use immutable commit SHA for workflow_run to prevent TOCTOU attacks
-          # For workflow_dispatch, use default ref (main)
-          ref: ${{ github.event.workflow_run.head_commit.sha || github.ref }}
+          # Use immutable commit SHA to prevent TOCTOU attacks
+          # For workflow_run: use head_commit.sha
+          # For pull_request: use pull_request.head.sha
+          # For workflow_dispatch: use default ref (main)
+          ref: ${{ github.event.workflow_run.head_commit.sha || github.event.pull_request.head.sha || github.ref }}
 
       - name: Snyk Monitor
         run: |

--- a/.github/workflows/scan-snyk.yml
+++ b/.github/workflows/scan-snyk.yml
@@ -1,21 +1,78 @@
---- 
+---
 
 name: scan-snyk
+
+# Security: This workflow uses the GitHub Actions security best practices pattern
+# for workflows that require secret access with pull requests:
+# https://securitylab.github.com/resources/github-actions-new-patterns-and-mitigations/
+#
+# - workflow_dispatch: Manual triggers (always trusted)
+# - workflow_run: Only after macos workflow completes on main branch
+#
+# The privileged (secret-accessing) workflow_run workflow is separated from
+# untrusted pull request code execution to prevent secret exfiltration attacks.
+
 on:
   workflow_dispatch: ~
-  workflow_call: ~
+  workflow_run:
+    workflows: [macos]
+    types: [completed]
+    branches: [main]
+
 permissions:
   contents: read
+
 jobs:
+  validate-trigger:
+    name: Validate workflow trigger source
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Log manual trigger
+        run: echo "Manual workflow_dispatch trigger - proceeding with secret access"
+
   scan-snyk:
     name: scan-snyk
     runs-on: macos-15-large
     timeout-minutes: 5
-    env:
-      SNYK_TOKEN: ${{ secrets.SNYK_AUTH_TOKEN }}
+    # Security: Only run on trusted sources to prevent secret exfiltration
+    # - Manual triggers (workflow_dispatch) are always trusted
+    # - workflow_run: prevent attacks from forked PRs by ensuring:
+    #   1. The triggering workflow completed successfully
+    #   2. The PR originates from the main repository (not a fork)
+    #   3. We use immutable commit SHA to prevent TOCTOU attacks
+    if: |
+      github.event_name == 'workflow_dispatch' || (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_repository != null &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      )
     steps:
+      - name: Validate security context
+        run: |
+          # Ensure we have proper context for secret access
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            # For workflow_run: verify we're not in a forked context
+            if [[ "${{ github.event.workflow_run.head_repository.full_name }}" != "${{ github.repository }}" ]]; then
+              echo "Security Error: Attempting to use secrets from a forked pull request"
+              exit 1
+            fi
+            echo "Security: Using immutable commit SHA from workflow_run context"
+            echo "Commit: ${{ github.event.workflow_run.head_commit.sha }}"
+          else
+            echo "Security: Manual trigger - proceeding with secret access"
+          fi
+
       - uses: actions/checkout@v6
+        with:
+          # Use immutable commit SHA for workflow_run to prevent TOCTOU attacks
+          # For workflow_dispatch, use default ref (main)
+          ref: ${{ github.event.workflow_run.head_commit.sha || github.ref }}
+
       - name: Snyk Monitor
         run: |
           brew install snyk-cli
           snyk monitor --org="3308b36d-5e52-4d0f-b167-3bd1b5fb764f"
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_AUTH_TOKEN }}

--- a/.github/workflows/scan-snyk.yml
+++ b/.github/workflows/scan-snyk.yml
@@ -26,14 +26,6 @@ permissions:
   contents: read
 
 jobs:
-  validate-trigger:
-    name: Validate workflow trigger source
-    runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
-    steps:
-      - name: Log manual trigger
-        run: echo "Manual workflow_dispatch trigger - proceeding with secret access"
-
   scan-snyk:
     name: scan-snyk
     runs-on: macos-15-large


### PR DESCRIPTION
This workflow uses the GitHub Actions security best practices pattern
for workflows that require secret access with pull requests:
- https://securitylab.github.com/resources/github-actions-new-patterns-and-mitigations/

The privileged (secret-accessing) workflow_run workflow is separated from
untrusted pull request code execution to prevent secret exfiltration attacks.

Also support for GitHub labels, so if added then it will run too