### PR TITLE
Deprecate 'withServerUrl' in configuration options

### DIFF
--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -32,7 +32,11 @@ ElasticApmAgent.start(with:config)
 
 You can configure the `AgentConfigBuilder` with the following functions.
 
-### `withServerUrl` [withServerUrl] **Deprecated**
+### `withServerUrl` [withServerUrl]
+```{applies_to}
+product:
+   edot_ios: deprecated v1.4.0
+```
 
 * **Type:** URL
 * **Default:** nil


### PR DESCRIPTION
Mark 'withServerUrl' as deprecated in configuration documentation with `{applies_to}`