### PR TITLE
docs: rename EDOT to Elastic OTel iOS for 9.5 rebrand

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -12,9 +12,9 @@ toc:
 
 subs:
   motlp: Elastic Cloud Managed OTLP Endpoint
-  edot: Elastic Distribution of OpenTelemetry
+  edot: Elastic OpenTelemetry
   ecloud:   "Elastic Cloud"
-  edot-cf:   "EDOT Cloud Forwarder"
+  edot-cf:   "Elastic Cloud Forwarder"
   ech:   "Elastic Cloud Hosted"
   ess:   "Elasticsearch Service"
   ece:   "Elastic Cloud Enterprise"

--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Configuration
-description: Configure the Elastic Distribution of OpenTelemetry iOS (EDOT iOS) to send data to Elastic.
+description: Configure the Elastic OTel iOS to send data to Elastic.
 applies_to:
   stack:
   serverless:
@@ -15,7 +15,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/swift/current/configuration.html
 ---
 
-# Configure the EDOT iOS SDK [configuration]
+# Configure the Elastic OTel iOS SDK [configuration]
 
 Configure the SDK with `AgentConfigBuilder` passing the `AgentConfiguration` to the `start` function.
 
@@ -106,10 +106,10 @@ Selects the transport used to export OTLP data to the collector. `.grpc` uses th
 
 ### TLS connections [tls-connections]
 
-EDOT iOS supports TLS connections to OTLP endpoints and OpAMP (central configuration) endpoints when the server uses a TLS certificate signed by a trusted Certificate Authority (CA).
+Elastic OTel iOS supports TLS connections to OTLP endpoints and OpAMP (central configuration) endpoints when the server uses a TLS certificate signed by a trusted Certificate Authority (CA).
 
 :::{warning}
-Self-signed certificates are **not supported**. If your endpoint uses a self-signed certificate, EDOT iOS will not be able to establish a secure connection. Ensure your server uses a certificate issued by a publicly trusted CA or an internal CA that is trusted by the device.
+Self-signed certificates are **not supported**. If your endpoint uses a self-signed certificate, Elastic OTel iOS will not be able to establish a secure connection. Ensure your server uses a certificate issued by a publicly trusted CA or an internal CA that is trusted by the device.
 :::
 
 ### `useOpAMP` [useOpAMP]
@@ -270,14 +270,14 @@ You can set this value dynamically at runtime.
 | `1.0` | Double | true |
 
 
-## Central configuration (EDOT)
+## Central configuration [central-configuration-edot]
 
 ```{applies_to}
 product:
   edot_ios: preview 1.4.0
 ```
 
-You can remotely manage the EDOT iOS behavior through [Central configuration](opentelemetry://reference/central-configuration.md) and the EDOT Collector. 
+You can remotely manage the Elastic OTel iOS behavior through [Central configuration](opentelemetry://reference/central-configuration.md) and the {{agent}}. 
 
 ### Activate central configuration
 
@@ -302,4 +302,4 @@ If you don't use [`useOpAMP()`](#useopamp), the default Elastic central configur
 
 ### Central configuration settings
 
-The same [Dynamic configuration](#dynamic-configuration) settings are available when using central configuration through the EDOT Collector.
+The same [Dynamic configuration](#dynamic-configuration) settings are available when using central configuration through the {{agent}}.

--- a/docs/reference/edot-ios/index.md
+++ b/docs/reference/edot-ios/index.md
@@ -1,6 +1,6 @@
 ---
-navigation_title: EDOT iOS
-description: The Elastic Distribution of OpenTelemetry iOS (EDOT iOS) is an APM agent based on OpenTelemetry. It provides built-in tools and configurations to make the OpenTelemetry SDK work with Elastic using as little code as possible while fully leveraging the combined forces of Elasticsearch and Kibana for your iOS application.
+navigation_title: Elastic OTel iOS
+description: Elastic OTel iOS is an APM agent based on OpenTelemetry. It provides built-in tools and configurations to make the OpenTelemetry SDK work with Elastic using as little code as possible while fully leveraging the combined forces of Elasticsearch and Kibana for your iOS application.
 applies_to:
   stack:
   serverless:
@@ -16,13 +16,13 @@ mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/swift/current/index.html
 ---
 
-# Elastic Distribution of OpenTelemetry iOS [intro]
+# Elastic OTel iOS [intro]
 
-The Elastic Distribution of OpenTelemetry iOS (EDOT iOS) measures the performance of your mobile applications in real time.
+Elastic OTel iOS measures the performance of your mobile applications in real time.
 
-## How does EDOT iOS work? [how-it-works]
+## How does Elastic OTel iOS work? [how-it-works]
 
-The Elastic Distribution of OpenTelemetry iOS uses the [OpenTelemetry-Swift SDK](https://github.com/open-telemetry/opentelemetry-swift). The agent automatically traces URLSessions and provides distributed traces annotated with device information along with your back-end services instrumented with OpenTelemetry.
+Elastic OTel iOS uses the [OpenTelemetry-Swift SDK](https://github.com/open-telemetry/opentelemetry-swift). The agent automatically traces URLSessions and provides distributed traces annotated with device information along with your back-end services instrumented with OpenTelemetry.
 
 The SDK also captures any custom OpenTelemetry traces or measurements created using the OpenTelemetry-Swift API.
 
@@ -41,11 +41,11 @@ You can find examples in the [opentelemetry-swift/examples](https://github.com/o
 
 ## Additional components [additional-components]
 
-EDOT SDKs work with the [APM Server](docs-content://solutions/observability/apm/index.md), [{{es}}](docs-content://get-started/index.md), and [{{kib}}](docs-content://get-started/the-stack.md). The [APM Guide](docs-content://solutions/observability/apm/index.md) provides details on how these components work together, and provides a matrix outlining [Agent and Server compatibility](docs-content://solutions/observability/apm/apm-agent-compatibility.md).
+Elastic OTel SDKs work with the [APM Server](docs-content://solutions/observability/apm/index.md), [{{es}}](docs-content://get-started/index.md), and [{{kib}}](docs-content://get-started/the-stack.md). The [APM Guide](docs-content://solutions/observability/apm/index.md) provides details on how these components work together, and provides a matrix outlining [Agent and Server compatibility](docs-content://solutions/observability/apm/apm-agent-compatibility.md).
 
 ## OpenTelemetry Components [_open_telemetry_components]
 
-The EDOT iOS SDK uses several OpenTelemetry-Swift libraries to provide automatic instrumentation of your applications and services. Details about these instrumentation libraries can be found in the official [opentelementry.io Swift Libraries documentation](https://opentelemetry.io/docs/instrumentation/swift/libraries/).
+The Elastic OTel iOS SDK uses several OpenTelemetry-Swift libraries to provide automatic instrumentation of your applications and services. Details about these instrumentation libraries can be found in the official [opentelementry.io Swift Libraries documentation](https://opentelemetry.io/docs/instrumentation/swift/libraries/).
 
 For network instrumentation, the agent uses `NSURLSessionInstrumentation`. This provides network instrumentation in the form of spans and enables distributed tracing for all instrumented downstream services.
 

--- a/docs/reference/edot-ios/instrumentation.md
+++ b/docs/reference/edot-ios/instrumentation.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Instrumentations
-description: Learn about the various instrumentation provided by the Elastic Distribution of OpenTelemetry iOS (EDOT iOS).
+description: Learn about the various instrumentation provided by Elastic OTel iOS.
 applies_to:
   stack:
   serverless:
@@ -15,9 +15,9 @@ mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/swift/current/Instrumentation.html
 ---
 
-# EDOT iOS instrumentations [Instrumentation]
+# Elastic OTel iOS instrumentations [Instrumentation]
 
-The following list describes the various instrumentation provided with the Elastic Distribution of OpenTelemetry iOS (EDOT iOS). These instrumentations can be configured as described in [instrumentation configuration](configuration.md#instrumentationConfiguration).
+The following list describes the various instrumentation provided with Elastic OTel iOS. These instrumentations can be configured as described in [instrumentation configuration](configuration.md#instrumentationConfiguration).
 
 ## Crash reporting [crash-reporting]
 

--- a/docs/reference/edot-ios/set-up-apm-ios-agent.md
+++ b/docs/reference/edot-ios/set-up-apm-ios-agent.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Setup
-description: Set up the Elastic Distribution of OpenTelemetry iOS (EDOT iOS) to send data to Elastic.
+description: Set up the Elastic OTel iOS to send data to Elastic.
 applies_to:
   stack:
   serverless:
@@ -17,7 +17,7 @@ mapped_pages:
 
 # Set up the APM iOS Agent [setup]
 
-Learn how to set up and configure the Elastic Distribution of OpenTelemetry iOS (EDOT iOS) to instrument your application.
+Learn how to set up and configure Elastic OTel iOS to instrument your application.
 
 ## Requirements [requirements]
 
@@ -34,7 +34,7 @@ Other platform requires:
 
 ## Add the SDK dependency [add-agent-dependency]
 
-Add the Elastic Distribution of OpenTelemetry iOS to your Xcode project or your `Package.swift`.
+Add Elastic OTel iOS to your Xcode project or your `Package.swift`.
 
 Here are instructions for adding a [package dependency](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to a standard Xcode project.
 

--- a/docs/reference/edot-ios/supported-technologies.md
+++ b/docs/reference/edot-ios/supported-technologies.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Supported technologies
-description: Technologies supported by the Elastic Distribution of OpenTelemetry iOS.
+description: Technologies supported by Elastic OTel iOS.
 applies_to:
   stack:
   serverless:
@@ -15,9 +15,9 @@ mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/swift/current/supported-technologies.html
 ---
 
-# Technologies supported by EDOT iOS SDK [supported-technologies]
+# Technologies supported by Elastic OTel iOS SDK [supported-technologies]
 
-The Elastic Distribution of OpenTelemetry iOS automatically instruments various APIs, frameworks, and application servers. This section lists all supported technologies.
+Elastic OTel iOS automatically instruments various APIs, frameworks, and application servers. This section lists all supported technologies.
 
 :::{note} - Understanding auto-instrumentation scope
 


### PR DESCRIPTION
## Summary

- Prose-only rebrand from "EDOT" / "Elastic Distribution of OpenTelemetry" to "Elastic OTel iOS" (SDK-specific) and "Elastic OpenTelemetry" (generic) across all reference docs.
- `docs/docset.yml` subs updated: `edot` → `Elastic OpenTelemetry`, `edot-cf` → `Elastic Cloud Forwarder`.
- "EDOT Collector" references replaced with `{{agent}}` (Elastic Agent).
- Machine identifiers are **unchanged**: URL path slugs (`edot-ios/`), `applies_to` product IDs (`edot_ios`, `edot-sdk`), Swift identifiers, env vars, and all release-notes / changelog entries for pre-9.5 versions are preserved as historical record.
- One explicit anchor added to preserve an old heading slug: `[central-configuration-edot]` in `configuration.md`.

## Held as draft for coordinated merge on July 28 2026 (9.5 GA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)