### PR TITLE
chore(deps): require swift-nio-ssl 2.37.2 or later

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
     .package(url: "https://github.com/MobileNativeFoundation/Kronos.git", .upToNextMajor(from: "4.2.2")),
     .package(
       url: "https://github.com/microsoft/plcrashreporter.git", .upToNextMajor(from: "1.12.0")),
+    .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.37.2"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Adds an explicit minimum version constraint for `swift-nio-ssl`, which is already part of the dependency graph via `grpc-swift`. This ensures builds resolve an up-to-date release of the package.

- `swift test` (macOS): 46/46 passing
- iOS simulator build + test run: passing