### PR TITLE
fix(ci): use GH_TOKEN so gh CLI can authenticate in labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -58,7 +58,7 @@ jobs:
         item_id=$(gh project item-add 1674 --url https://github.com/elastic/apm-agent-ios/pull/$PR_NUMBER --owner elastic --format json --jq .id)
         gh project item-edit --id "$item_id" --project-id "$PROJECT_ID" --field-id "$FIELD_ID" --single-select-option-id "$OPTION_ID"
       env:
-        MY_GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
+        GH_TOKEN: ${{ steps.get_token.outputs.token }}
         PROJECT_ID: 'PVT_kwDOAGc3Zs4Am42e'
         FIELD_ID: 'PVTSSF_lADOAGc3Zs4Am42ezgetx6g'
         OPTION_ID: 'f37476bf'


### PR DESCRIPTION
The **Assign new internal pull requests to project** step in `labeler.yml` passes the GitHub App token as `MY_GITHUB_TOKEN`, an env var the `gh` CLI does not read. When the step actually runs, `gh project item-add` fails with:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
```

The bug has been latent since #337 (April) because the step is gated to PRs authored by team members and was **skipped** on every run since — it first executed (and failed) on #362.

Fix: rename the env var to `GH_TOKEN`.