### PR TITLE
test: make OpampHttpRequestService tests deterministic with injectable timer

### DIFF
--- a/Sources/Tests/apm-agent-iosTests/Opamp/mocks/MockOpampSender.swift
+++ b/Sources/Tests/apm-agent-iosTests/Opamp/mocks/MockOpampSender.swift
@@ -16,17 +16,18 @@
 import Foundation
 @testable import ElasticApm
 
-
 class MockOpampSender: OpampSender {
+  private(set) var sendCount = 0
+
   func send(
     opampRequest: ElasticApm.OpampRequest,
     completion: @escaping (
       Result<(ElasticApm.OpampResponse, URLResponse), any Error>
     ) -> Void
   ) {
+    sendCount += 1
     completion(sender())
   }
-
 
   let sender: () -> Result<(OpampResponse, URLResponse), Error>
 
@@ -62,7 +63,7 @@ class MockOpampSender: OpampSender {
         (
           response,
           HTTPURLResponse(
-            url:OpampHttpRequestService.defaultURL ,
+            url: OpampHttpRequestService.defaultURL,
             statusCode: 200,
             httpVersion: nil,
             headerFields: nil

--- a/Sources/Tests/apm-agent-iosTests/Opamp/mocks/MockRequestTimer.swift
+++ b/Sources/Tests/apm-agent-iosTests/Opamp/mocks/MockRequestTimer.swift
@@ -1,0 +1,62 @@
+//
+//  Copyright © 2026  Elasticsearch BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+import Foundation
+@testable import ElasticApm
+
+/// Deterministic RequestTimer for tests: records every schedule and only
+/// fires when the test calls `fire()`, so no assertions depend on wall-clock time.
+class MockRequestTimer: RequestTimer {
+
+  struct Schedule: Equatable {
+    let delay: TimeInterval
+    let repeating: TimeInterval?
+  }
+
+  private var handler: (() -> Void)?
+  private(set) var schedules = [Schedule]()
+  private(set) var isActivated = false
+  private(set) var isCancelled = false
+
+  var lastSchedule: Schedule? { schedules.last }
+
+  func setEventHandler(_ handler: @escaping () -> Void) {
+    self.handler = handler
+  }
+
+  func schedule(delay: TimeInterval, repeating: TimeInterval?) {
+    // a real DispatchSourceTimer ignores schedules after cancellation
+    if isCancelled {
+      return
+    }
+    schedules.append(Schedule(delay: delay, repeating: repeating))
+  }
+
+  func activate() {
+    isActivated = true
+  }
+
+  func cancel() {
+    isCancelled = true
+  }
+
+  /// Simulates the timer firing, like a DispatchSourceTimer reaching its deadline.
+  func fire() {
+    guard isActivated, !isCancelled else {
+      return
+    }
+    handler?()
+  }
+}

--- a/Sources/Tests/apm-agent-iosTests/Opamp/request/OpampHttpRequestServiceTest.swift
+++ b/Sources/Tests/apm-agent-iosTests/Opamp/request/OpampHttpRequestServiceTest.swift
@@ -17,19 +17,22 @@ import Foundation
 import XCTest
 @testable import ElasticApm
 
-public class OpampHttpRequestServiceTest : XCTestCase {
+public class OpampHttpRequestServiceTest: XCTestCase {
+
+  private func emptyRequestSupplier() -> AnonymousSupplier<OpampRequest> {
+    return AnonymousSupplier<OpampRequest> {
+      return OpampRequest(agentToServer: Opamp_Proto_AgentToServer())
+    }
+  }
 
   func testRequestServiceStates() {
-
-    let cond = NSCondition()
-
-    var counter = 0
-
+    let timer = MockRequestTimer()
+    let sender = MockOpampSender.getWith(statusCode: 500)
     let requestService = OpampHttpRequestService(
-      httpClient: MockOpampSender
-        .getWith(statusCode: 500),
-      requestDelay: 50000.0,
-      retryDelay: 1.0
+      httpClient: sender,
+      requestDelay: 30.0,
+      retryDelay: 1.0,
+      timer: timer
     )
 
     XCTAssertFalse(requestService.isRunning)
@@ -39,29 +42,22 @@ public class OpampHttpRequestServiceTest : XCTestCase {
     // stopping before started makes no changes
     XCTAssertFalse(requestService.isRunning)
     XCTAssertFalse(requestService.isStopped)
-
-
-    requestService
-      .start(
-        callback: MockRequestServiceCallback(onRequestFailed: { error, delay in
-          cond.lock()
-          counter += 1
-          cond.broadcast()
-          cond.unlock()
-        }),
-        request: AnonymousSupplier<OpampRequest> { return OpampRequest(
-          agentToServer: Opamp_Proto_AgentToServer()
-        )
-        }
-      )
-
-    XCTAssertTrue(requestService.isRunning)
-    XCTAssertFalse(requestService.isStopped)
+    XCTAssertFalse(timer.isCancelled)
 
     requestService
       .start(
         callback: MockRequestServiceCallback(),
-        request: AnonymousSupplier<OpampRequest> { return OpampRequest(agentToServer: Opamp_Proto_AgentToServer()) }
+        request: emptyRequestSupplier()
+      )
+
+    XCTAssertTrue(requestService.isRunning)
+    XCTAssertFalse(requestService.isStopped)
+    XCTAssertTrue(timer.isActivated)
+
+    requestService
+      .start(
+        callback: MockRequestServiceCallback(),
+        request: emptyRequestSupplier()
       )
     // calling start twice makes no changes
     XCTAssertTrue(requestService.isRunning)
@@ -70,215 +66,179 @@ public class OpampHttpRequestServiceTest : XCTestCase {
     requestService.stop()
 
     XCTAssertTrue(requestService.isStopped)
+    XCTAssertTrue(timer.isCancelled)
 
     requestService
       .start(
         callback: MockRequestServiceCallback(),
-        request: AnonymousSupplier<OpampRequest> { return OpampRequest(agentToServer: Opamp_Proto_AgentToServer()) }
+        request: emptyRequestSupplier()
       )
-
+    // starting after stop makes no changes
     XCTAssertTrue(requestService.isStopped)
 
-    requestService.sendRequest() // noop?
-
-    let start = Date()
-    cond.lock()
-    while (counter < 1 && Date().timeIntervalSince1970 - start.timeIntervalSince1970 < 10.0) {
-      cond.wait(until: Date(timeIntervalSinceNow: 1.0))
-    }
-    XCTAssertEqual(counter, 0, "requestService sendRequest executed")
-    cond.unlock()
-
+    requestService.sendRequest()
+    timer.fire()
+    // the cancelled timer no longer fires, so no request is sent
+    XCTAssertEqual(sender.sendCount, 0, "requestService sendRequest executed")
   }
 
   func testReqeustServiceSendsOnDemand() {
+    let timer = MockRequestTimer()
+    let requestFailed = expectation(description: "request failed callback")
     let requestService = OpampHttpRequestService(
-      httpClient: MockOpampSender
-        .getWith(statusCode: 500),
-      requestDelay: 10000.0,
-      retryDelay: 1.0
+      httpClient: MockOpampSender.getWith(statusCode: 500),
+      requestDelay: 30.0,
+      retryDelay: 1.0,
+      timer: timer
     )
 
-    let cond = NSCondition()
-    var counter = 0
-    var start = Date()
     requestService
       .start(
-        callback: MockRequestServiceCallback(onRequestFailed: { error, delay in
-          cond.lock()
-          counter += 1
-          let date = Date()
-          if (counter == 1) {
-
-            XCTAssertLessThan(date.timeIntervalSince1970 - start.timeIntervalSince1970, 10, "callback executed much sooner than reqeustDelay")
-            start = date
-          } else if counter == 2 {
-            XCTAssertEqual(date.timeIntervalSince1970 - start.timeIntervalSince1970, 1.0, accuracy: 1.0, "Retry delay is only about 1 second")
-          }
-          cond.broadcast()
-          cond.unlock()
+        callback: MockRequestServiceCallback(onRequestFailed: { _, _ in
+          requestFailed.fulfill()
         }),
-        request: AnonymousSupplier<OpampRequest> { return OpampRequest(agentToServer: Opamp_Proto_AgentToServer()) }
+        request: emptyRequestSupplier()
       )
 
-      requestService.sendRequest()
+    // the initial schedule waits a full requestDelay
+    XCTAssertEqual(
+      timer.lastSchedule,
+      MockRequestTimer.Schedule(delay: 30.0, repeating: 30.0)
+    )
 
-    cond.lock()
-    while (counter < 2 && Date().timeIntervalSince1970 - start.timeIntervalSince1970 < 20.0) {
-      cond.wait(until: Date(timeIntervalSinceNow: 1.0))
-    }
-    XCTAssertEqual(counter, 2, "condtional timed out")
-    cond.unlock()
+    requestService.sendRequest()
+    // sending on demand reschedules the timer to fire immediately
+    XCTAssertEqual(
+      timer.lastSchedule,
+      MockRequestTimer.Schedule(delay: 0, repeating: 30.0)
+    )
+
+    timer.fire()
+    wait(for: [requestFailed], timeout: 10.0)
     requestService.stop()
   }
 
   func testHttpFailedRequest() {
-    let cond = NSCondition()
+    let timer = MockRequestTimer()
+    let requestFailed = expectation(description: "request failed callback")
     let requestService = OpampHttpRequestService(
-      httpClient: MockOpampSender
-        .getWith(statusCode: 500),
+      httpClient: MockOpampSender.getWith(statusCode: 500),
       requestDelay: 5.0,
-      retryDelay: 1.0
+      retryDelay: 1.0,
+      timer: timer
     )
 
-
-    let start = Date()
-    var isWaiting = true
     requestService
       .start(
         callback: MockRequestServiceCallback(
-          onRequestFailed: {
-            error,
-            delay in
-            let end = Date()
-            XCTAssert((error as NSError).code == 500)
-            XCTAssertEqual(
-              end.timeIntervalSince1970 - start.timeIntervalSince1970,
-              5.0,
-              accuracy: 1.0
-            )
-            cond.lock()
-            isWaiting = false
-            cond.broadcast()
-            cond.unlock()
+          onRequestFailed: { error, retryAfter in
+            XCTAssertEqual((error as NSError).code, 500)
+            XCTAssertEqual(retryAfter, 1.0)
+            requestFailed.fulfill()
           }),
-        request: AnonymousSupplier<OpampRequest> { return OpampRequest(agentToServer: Opamp_Proto_AgentToServer()) }
+        request: emptyRequestSupplier()
       )
 
-
-    cond.lock()
-    while (isWaiting) {
-      cond.wait()
-    }
-    cond.unlock()
+    timer.fire()
+    // a failed request enables retry mode on the retryDelay timescale
+    XCTAssertEqual(
+      timer.lastSchedule,
+      MockRequestTimer.Schedule(delay: 1.0, repeating: 1.0)
+    )
+    wait(for: [requestFailed], timeout: 10.0)
     requestService.stop()
   }
 
-
   func testHttpFailedConnect() {
-    let cond = NSCondition()
+    let timer = MockRequestTimer()
+    let connectFailed = expectation(description: "connection failure callback")
     let requestService = OpampHttpRequestService(
       httpClient: MockOpampSender
         .getWith(
           error: NSError(
             domain: HTTPURLResponse
-              .localizedString(forStatusCode:NSURLErrorTimedOut),
-            code:NSURLErrorTimedOut
+              .localizedString(forStatusCode: NSURLErrorTimedOut),
+            code: NSURLErrorTimedOut
           )
         ),
       requestDelay: 5.0,
-      retryDelay: 1.0
+      retryDelay: 1.0,
+      timer: timer
     )
 
-    let start = Date()
-    var isWaiting = true
     requestService
       .start(
         callback: MockRequestServiceCallback(
-          onConnectFailure: {
-            error,
-            delay in
-            let end = Date()
-            XCTAssert((error as NSError).code == NSURLErrorTimedOut)
-            XCTAssertEqual(
-              end.timeIntervalSince1970 - start.timeIntervalSince1970,
-              5.0,
-              accuracy: 1.0
-            )
-            cond.lock()
-            isWaiting = false
-            cond.broadcast()
-            cond.unlock()
+          onConnectFailure: { error, retryAfter in
+            XCTAssertEqual((error as NSError).code, NSURLErrorTimedOut)
+            XCTAssertEqual(retryAfter, 1.0)
+            connectFailed.fulfill()
           }),
-        request: AnonymousSupplier<OpampRequest> { return OpampRequest(agentToServer: Opamp_Proto_AgentToServer()) })
+        request: emptyRequestSupplier()
+      )
 
-    cond.lock()
-    while (isWaiting) {
-      cond.wait()
-    }
-    cond.unlock()
+    timer.fire()
+    // a network error enables retry mode with exponential backoff (1 skip)
+    XCTAssertEqual(
+      timer.lastSchedule,
+      MockRequestTimer.Schedule(delay: 1.0, repeating: 1.0)
+    )
+    wait(for: [connectFailed], timeout: 10.0)
     requestService.stop()
   }
 
   func testHttpFailureUpdatesRetryDelayHeader() {
-    let cond = NSCondition()
+    let timer = MockRequestTimer()
+    let requestFailed = expectation(description: "request failed callback")
+    requestFailed.expectedFulfillmentCount = 2
     let requestService = OpampHttpRequestService(
       httpClient: MockOpampSender(
-sender: {
-        let response = HTTPURLResponse(url: URL(string: "http://localhost")!,
-                                       statusCode: 503,
-                                       httpVersion: nil,
-                                       headerFields: ["Retry-After": "3"]
-                                               )!
-  return .success((OpampResponse(serverToAgent:  Opamp_Proto_ServerToAgent()), response))
-
-      }),
+        sender: {
+          let response = HTTPURLResponse(
+            url: URL(string: "http://localhost")!,
+            statusCode: 503,
+            httpVersion: nil,
+            headerFields: ["Retry-After": "3"]
+          )!
+          return .success((OpampResponse(serverToAgent: Opamp_Proto_ServerToAgent()), response))
+        }),
       requestDelay: 1.0,
-      retryDelay: 1000.0
+      retryDelay: 1000.0,
+      timer: timer
     )
 
-    let start = Date()
-    var isWaiting = true
-    var iteration = 0
     requestService
       .start(
         callback: MockRequestServiceCallback(
-          onRequestFailed: {
-            error,
-            delay in
-            XCTAssert((error as NSError).code == 503)
-            iteration+=1
-            if iteration == 1 {
-              XCTAssertEqual(Date().timeIntervalSince1970 - start.timeIntervalSince1970, 1.0, accuracy: 0.5,
-                             "reqeustDelay incorrect"
-              )
-            } else if (iteration == 2) {
-              // second iteration should be on the retryDelay timescale
-              XCTAssertEqual(
-                Date().timeIntervalSince1970 - start.timeIntervalSince1970,
-                4.0,
-                accuracy: 0.5,
-                "retryDelay with exponential backoff incorrect"
-              )
-              cond.lock()
-              isWaiting = false
-              cond.broadcast()
-              cond.unlock()
-            }
+          onRequestFailed: { error, retryAfter in
+            XCTAssertEqual((error as NSError).code, 503)
+            // the Retry-After header takes precedence over the configured retryDelay
+            XCTAssertEqual(retryAfter, 3.0)
+            requestFailed.fulfill()
           }),
-        request: AnonymousSupplier<OpampRequest> { return OpampRequest(agentToServer: Opamp_Proto_AgentToServer()) })
+        request: emptyRequestSupplier()
+      )
 
+    timer.fire()
+    // retry mode uses the Retry-After header value
+    XCTAssertEqual(
+      timer.lastSchedule,
+      MockRequestTimer.Schedule(delay: 3.0, repeating: 3.0)
+    )
 
-    cond.lock()
-    while (isWaiting) {
-      cond.wait()
-    }
-    cond.unlock()
+    let schedulesAfterFirstFailure = timer.schedules.count
+    timer.fire()
+    // retry mode is already enabled, so the second failure does not reschedule
+    XCTAssertEqual(timer.schedules.count, schedulesAfterFirstFailure)
+
+    wait(for: [requestFailed], timeout: 10.0)
     requestService.stop()
   }
 
   func testRetryErrorResponse() {
-    let cond = NSCondition()
+    let timer = MockRequestTimer()
+    let requestSucceeded = expectation(description: "request success callback")
+    requestSucceeded.expectedFulfillmentCount = 2
 
     var serverToAgent = Opamp_Proto_ServerToAgent()
     serverToAgent.errorResponse = Opamp_Proto_ServerErrorResponse()
@@ -288,105 +248,82 @@ sender: {
       httpClient: MockOpampSender
         .getSuccess(with: OpampResponse.init(serverToAgent: serverToAgent)),
       requestDelay: 5.0,
-      retryDelay: 1.0
+      retryDelay: 1.0,
+      timer: timer
     )
 
-    let start = Date()
-    var isWaiting = true
-    var iteration = 0
     requestService
       .start(
         callback: MockRequestServiceCallback(
-         onRequestSuccess: {
-           response
-             in
-           iteration+=1
-           if iteration == 1 {
-             XCTAssertEqual(Date().timeIntervalSince1970 - start.timeIntervalSince1970, 5.0, accuracy: 0.5,
-              "reqeustDelay incorrect"
-             )
-           } else if (iteration == 2) {
-             // second iteration should be on the retryDelay timescale
-             XCTAssertEqual(
-              Date().timeIntervalSince1970 - start.timeIntervalSince1970,
-              6.0,
-              accuracy: 0.5,
-              "retryDelay with exponential backoff incorrect"
-             )
-             cond.lock()
-             isWaiting = false
-             cond.broadcast()
-             cond.unlock()
-           }
+          onRequestSuccess: { _ in
+            requestSucceeded.fulfill()
           }),
-        request: AnonymousSupplier<OpampRequest> { return OpampRequest(agentToServer: Opamp_Proto_AgentToServer()) })
+        request: emptyRequestSupplier()
+      )
 
-    cond.lock()
-    while (isWaiting) {
-      cond.wait()
-    }
-    cond.unlock()
+    timer.fire()
+    // the server error response enables retry mode on the retryDelay timescale
+    XCTAssertEqual(
+      timer.lastSchedule,
+      MockRequestTimer.Schedule(delay: 1.0, repeating: 1.0)
+    )
+
+    timer.fire()
+    // the successful HTTP response first restores the requestDelay schedule,
+    // then the embedded error response re-enables retry mode
+    XCTAssertEqual(
+      timer.schedules.suffix(2),
+      [
+        MockRequestTimer.Schedule(delay: 5.0, repeating: 5.0),
+        MockRequestTimer.Schedule(delay: 1.0, repeating: 1.0)
+      ]
+    )
+
+    wait(for: [requestSucceeded], timeout: 10.0)
     requestService.stop()
   }
 
   func testHandleMessageRetryDelayUpdated() {
-    let cond = NSCondition()
+    let timer = MockRequestTimer()
+    let requestSucceeded = expectation(description: "request success callback")
 
     var serverToAgent = Opamp_Proto_ServerToAgent()
     serverToAgent.errorResponse = Opamp_Proto_ServerErrorResponse()
     serverToAgent.errorResponse.errorMessage = "error"
     serverToAgent.errorResponse.type = .unavailable
     serverToAgent.errorResponse.retryInfo = Opamp_Proto_RetryInfo()
-    serverToAgent.errorResponse.retryInfo.retryAfterNanoseconds = 1_000_000_000 // 1 seconds
+    serverToAgent.errorResponse.retryInfo.retryAfterNanoseconds = 1_000_000_000 // 1 second
     let requestService = OpampHttpRequestService(
       httpClient: MockOpampSender
         .getSuccess(with: OpampResponse.init(serverToAgent: serverToAgent)),
       requestDelay: 1.0,
-      retryDelay: 1000.0
+      retryDelay: 1000.0,
+      timer: timer
     )
 
-    let start = Date()
-    var isWaiting = true
-    var iteration = 0
     requestService
       .start(
         callback: MockRequestServiceCallback(
-          onRequestSuccess: {
-            response
-            in
-            iteration+=1
-            if iteration == 1 {
-              XCTAssertEqual(Date().timeIntervalSince1970 - start.timeIntervalSince1970, 1.0, accuracy: 0.5,
-                             "reqeustDelay incorrect"
-              )
-            } else if (iteration == 2) {
-              // second iteration should be on the retryDelay timescale
-              XCTAssertEqual(
-                Date().timeIntervalSince1970 - start.timeIntervalSince1970,
-                2.0,
-                accuracy: 0.5,
-                "retryDelay with exponential backoff incorrect"
-              )
-              cond.lock()
-              isWaiting = false
-              cond.broadcast()
-              cond.unlock()
-            }
+          onRequestSuccess: { _ in
+            requestSucceeded.fulfill()
           }),
-        request: AnonymousSupplier<OpampRequest> { return OpampRequest(agentToServer: Opamp_Proto_AgentToServer()) })
+        request: emptyRequestSupplier()
+      )
 
-    cond.lock()
-    while (isWaiting && Date().timeIntervalSince1970 - start.timeIntervalSince1970 < 10.0) {
-      cond.wait()
-    }
-    XCTAssertEqual(iteration, 2, "Timed Out: ReqeustService did not update retry delay from message.")
-    cond.unlock()
+    timer.fire()
+    // the message's retry info takes precedence over the configured retryDelay
+    XCTAssertEqual(
+      timer.lastSchedule,
+      MockRequestTimer.Schedule(delay: 1.0, repeating: 1.0)
+    )
+    wait(for: [requestSucceeded], timeout: 10.0)
     requestService.stop()
-
   }
 
   func testHandleNetworkError() {
-    let cond = NSCondition()
+    let timer = MockRequestTimer()
+    let connectFailed = expectation(description: "connection failure callback")
+    connectFailed.expectedFulfillmentCount = 2
     let retryDelay = 1.0
     let requestDelay = 3.0
     let requestService = OpampHttpRequestService(
@@ -395,59 +332,44 @@ sender: {
           error: NSError(
             domain: HTTPURLResponse
               .localizedString(forStatusCode: NSURLErrorTimedOut),
-            code:NSURLErrorTimedOut
+            code: NSURLErrorTimedOut
           )
         ),
       requestDelay: requestDelay,
-      retryDelay: retryDelay
+      retryDelay: retryDelay,
+      timer: timer
     )
 
-    let start = Date()
-    var isWaiting = true
-    var iteration = 0
     requestService
       .start(
         callback: MockRequestServiceCallback(
-          onConnectFailure: {
-            error,
- timeInterval
-            in
-            iteration+=1
-            if iteration == 1 {
-              XCTAssertEqual(
-                Date().timeIntervalSince1970 - start.timeIntervalSince1970,
-                requestDelay,
-                accuracy: 0.5,
-                             "reqeustDelay incorrect"
-              )
-            } else if (iteration == 2) {
-              // second iteration should be on the retryDelay timescale
-              XCTAssertEqual(
-                timeInterval,
-                retryDelay,
-                accuracy: 0.5,
-              )
-
-              XCTAssertEqual(
-                Date().timeIntervalSince1970 - start.timeIntervalSince1970,
-                requestDelay + retryDelay, accuracy: 0.5,
-              )
-              cond.lock()
-              isWaiting = false
-              cond.broadcast()
-              cond.unlock()
-            }
+          onConnectFailure: { error, timeInterval in
+            XCTAssertEqual((error as NSError).code, NSURLErrorTimedOut)
+            XCTAssertEqual(timeInterval, retryDelay)
+            connectFailed.fulfill()
           }),
-        request: AnonymousSupplier<OpampRequest> { return OpampRequest(agentToServer: Opamp_Proto_AgentToServer()) }
+        request: emptyRequestSupplier()
       )
 
-    cond.lock()
-    while (isWaiting && Date().timeIntervalSince1970 - start.timeIntervalSince1970 < 10.0) {
-      cond.wait()
-    }
-    XCTAssertEqual(iteration, 2, "Timed Out: ReqeustService did not retry.")
-    cond.unlock()
-    requestService.stop()
+    // the initial schedule waits a full requestDelay
+    XCTAssertEqual(
+      timer.lastSchedule,
+      MockRequestTimer.Schedule(delay: requestDelay, repeating: requestDelay)
+    )
 
+    timer.fire()
+    // the first network error enables retry mode on the retryDelay timescale
+    XCTAssertEqual(
+      timer.lastSchedule,
+      MockRequestTimer.Schedule(delay: retryDelay, repeating: retryDelay)
+    )
+
+    let schedulesAfterFirstFailure = timer.schedules.count
+    timer.fire()
+    // retry mode is already enabled, so further failures do not reschedule
+    XCTAssertEqual(timer.schedules.count, schedulesAfterFirstFailure)
+
+    wait(for: [connectFailed], timeout: 10.0)
+    requestService.stop()
   }
 }

--- a/Sources/apm-agent-ios/Configuration/Opamp/client/request/service/OpampHttpRequestService.swift
+++ b/Sources/apm-agent-ios/Configuration/Opamp/client/request/service/OpampHttpRequestService.swift
@@ -20,13 +20,10 @@ public class OpampHttpRequestService: RequestService {
   private let httpClient: OpampSender
   private let requestDelay: TimeInterval
   private let retryDelay: TimeInterval
-  private let requestQueue = DispatchQueue(
-    label: "com.elastic.apm.agent.opamp.http.request.timer",
-    qos: .utility)
   private let lock = NSLock()
   private var retryModeEnabled = false
   private var exponentialBackoffSkips = 0
-  private let requestTimer: DispatchSourceTimer
+  private let requestTimer: RequestTimer
 
   private var callback: RequestServiceCallback?
   private var request: (any Supplier<OpampRequest>)?
@@ -40,11 +37,12 @@ public class OpampHttpRequestService: RequestService {
     httpClient: OpampSender = OpampHttpSender(url: defaultURL),
     requestDelay: TimeInterval = 30.0,
     retryDelay: TimeInterval = 30.0,
+    timer: RequestTimer = DispatchSourceRequestTimer(),
   ) {
     self.httpClient = httpClient
     self.requestDelay = requestDelay
     self.retryDelay = retryDelay
-    self.requestTimer = DispatchSource.makeTimerSource(queue: requestQueue)
+    self.requestTimer = timer
     requestTimer.setEventHandler { [weak self] in
       autoreleasepool {
         guard let self = self else {
@@ -56,7 +54,7 @@ public class OpampHttpRequestService: RequestService {
 
     self.requestTimer
       .schedule(
-        deadline: .now() + requestDelay,
+        delay: requestDelay,
         repeating: requestDelay
       )
   }
@@ -64,11 +62,11 @@ public class OpampHttpRequestService: RequestService {
   public func start(callback: RequestServiceCallback, request: any Supplier<OpampRequest>) {
     lock.lock()
     defer { lock.unlock() }
-    if (isStopped) {
+    if isStopped {
       os_log("OpampHttpRequestService has been stopped.")
       return
     }
-    if (isRunning) {
+    if isRunning {
       os_log("OpampHttpReqeustService is already running.")
       return
     }
@@ -81,22 +79,21 @@ public class OpampHttpRequestService: RequestService {
   public func sendRequest() {
     lock.lock()
     defer { lock.unlock() }
-    self.requestTimer.schedule(deadline: .now(), repeating: self.requestDelay)
+    self.requestTimer.schedule(delay: 0, repeating: self.requestDelay)
   }
 
   public func stop() {
     lock.lock()
     defer { lock.unlock() }
-    if (!isRunning || isStopped) {
+    if !isRunning || isStopped {
       return
     }
     isStopped = true
-    requestTimer.schedule(deadline: .now(), repeating: .never)
+    requestTimer.schedule(delay: 0, repeating: nil)
     requestTimer.cancel()
   }
 
-
-  private func isSuccessful(_ response: URLResponse) -> Bool{
+  private func isSuccessful(_ response: URLResponse) -> Bool {
     if let httpResponse = response as? HTTPURLResponse {
       return httpResponse.statusCode >= 200 && httpResponse.statusCode < 300
     }
@@ -107,14 +104,11 @@ public class OpampHttpRequestService: RequestService {
       return response.statusCode == 429 || response.statusCode == 503
   }
 
-
-
-
   private func handleHttpError(_ response: URLResponse) {
     if let httpResponse = response as? HTTPURLResponse {
       var retryAfter: TimeInterval = retryDelay
       if shouldUpdateRetryDelay(httpResponse) {
-        if let retryAfterHeader = httpResponse.value(forHTTPHeaderField:"Retry-After") {
+        if let retryAfterHeader = httpResponse.value(forHTTPHeaderField: "Retry-After") {
           if let parsedRetryAfter =  Double(retryAfterHeader) {
             retryAfter = parsedRetryAfter
           } else if let parsedDate = OpampHttpDate.parse(dateString: retryAfterHeader) {
@@ -137,23 +131,21 @@ public class OpampHttpRequestService: RequestService {
     }
   }
 
-
   private func enableRetryMode(_ retryAfter: TimeInterval) {
     if !retryModeEnabled {
       retryModeEnabled = true
       self.requestTimer
-        .schedule(deadline: .now() + retryAfter, repeating: retryAfter)
+        .schedule(delay: retryAfter, repeating: retryAfter)
     }
   }
 
   private func disableRetryMode() {
     if retryModeEnabled {
       retryModeEnabled = false
-      self.requestTimer.schedule(deadline: .now() + self.requestDelay, repeating: self.requestDelay)
+      self.requestTimer.schedule(delay: self.requestDelay, repeating: self.requestDelay)
 
     }
   }
-
 
   private func handleErrorResponse(
     _ errorResponse: Opamp_Proto_ServerErrorResponse
@@ -166,19 +158,19 @@ public class OpampHttpRequestService: RequestService {
       } else {
         incrementExponentialBackoff()
       }
-    case .badRequest, .unknown, .UNRECOGNIZED(_):
+    case .badRequest, .unknown, .UNRECOGNIZED:
       incrementExponentialBackoff()
     }
   }
 
   private func incrementExponentialBackoff() {
-    if (exponentialBackoffSkips == 0) {
-      exponentialBackoffSkips = 1;
+    if exponentialBackoffSkips == 0 {
+      exponentialBackoffSkips = 1
     } else {
-      exponentialBackoffSkips *= 2;
+      exponentialBackoffSkips *= 2
     }
-    if (exponentialBackoffSkips >= 32) {
-      exponentialBackoffSkips = 32;
+    if exponentialBackoffSkips >= 32 {
+      exponentialBackoffSkips = 32
     }
     enableRetryMode(retryDelay * Double(exponentialBackoffSkips))
   }
@@ -214,24 +206,21 @@ public class OpampHttpRequestService: RequestService {
     defer { self.lock.unlock() }
     if let request = self.request?.get() {
       httpClient.send(
-opampRequest: request,
- completion: {
-        [weak self]
-        result in
-
-   guard let self = self else { return }
-        switch result {
-        case let .success((opampResponse, urlResponse)):
-          if isSuccessful(urlResponse) {
-            resetExponentialBackoffSkips()
-            handleResponse(opampResponse)
-          } else {
-            handleHttpError(urlResponse)
+        opampRequest: request,
+        completion: { [weak self] result in
+          guard let self = self else { return }
+          switch result {
+          case let .success((opampResponse, urlResponse)):
+            if isSuccessful(urlResponse) {
+              resetExponentialBackoffSkips()
+              handleResponse(opampResponse)
+            } else {
+              handleHttpError(urlResponse)
+            }
+          case let .failure(error):
+            handleNetworkError(error)
           }
-        case let .failure(error):
-          handleNetworkError(error)
-        }
-      })
+        })
     }
   }
 }

--- a/Sources/apm-agent-ios/Configuration/Opamp/client/request/service/RequestTimer.swift
+++ b/Sources/apm-agent-ios/Configuration/Opamp/client/request/service/RequestTimer.swift
@@ -1,0 +1,56 @@
+//
+//  Copyright © 2026  Elasticsearch BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+import Foundation
+
+protocol RequestTimer {
+  func setEventHandler(_ handler: @escaping () -> Void)
+  /// Schedules the next fire after `delay`. A `nil` `repeating` schedules a one-shot timer.
+  func schedule(delay: TimeInterval, repeating: TimeInterval?)
+  func activate()
+  func cancel()
+}
+
+class DispatchSourceRequestTimer: RequestTimer {
+  private let timer: DispatchSourceTimer
+
+  init(
+    queue: DispatchQueue = DispatchQueue(
+      label: "com.elastic.apm.agent.opamp.http.request.timer",
+      qos: .utility)
+  ) {
+    self.timer = DispatchSource.makeTimerSource(queue: queue)
+  }
+
+  func setEventHandler(_ handler: @escaping () -> Void) {
+    timer.setEventHandler(handler: handler)
+  }
+
+  func schedule(delay: TimeInterval, repeating: TimeInterval?) {
+    if let repeating = repeating {
+      timer.schedule(deadline: .now() + delay, repeating: repeating)
+    } else {
+      timer.schedule(deadline: .now() + delay, repeating: .never)
+    }
+  }
+
+  func activate() {
+    timer.activate()
+  }
+
+  func cancel() {
+    timer.cancel()
+  }
+}


### PR DESCRIPTION
## Summary

These changes should fix flaky tests

## Problem

`OpampHttpRequestServiceTest` asserts wall-clock elapsed time against `DispatchSourceTimer` scheduling with ±0.5s tolerances. On loaded CI simulators the timers fire late, and the lateness compounds across iterations, so the suite flakes regularly — three different tests in this suite failed across recent CI runs and local runs (`testRetryErrorResponse` on iOS, `testHandleNetworkError` on watchOS, `testRequestServiceStates` locally), each needing re-runs to go green.

## Fix

Make the tests deterministic instead of loosening tolerances:

- New `RequestTimer` protocol abstracting the timer operations `OpampHttpRequestService` needs (`setEventHandler`, `schedule`, `activate`, `cancel`).
- `DispatchSourceRequestTimer` is the production implementation wrapping the same `DispatchSourceTimer`/queue as before, injected as a default init argument — **no behavior or call-site changes in production code**.
- Tests inject a `MockRequestTimer` and drive firing manually with `fire()`, asserting the **delays the service schedules** (the actual contract: request delay, retry delay, Retry-After header, exponential backoff, retry-info from messages) rather than measuring real time.

Also fixes pre-existing SwiftLint violations in the touched files, since CI lints changed files in `--strict` mode.

## Results

- Suite runtime drops from ~77s to ~3ms (nothing sleeps anymore).
- 20 consecutive local runs of the suite: all green.
- Full `swift test`: 46/46 passing (whole run now ~3s instead of ~40s).
- `swiftlint lint --strict` clean on all changed files.