### PR TITLE
ci: add timeout-minutes: 30 to xcode-matrix job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,6 +57,7 @@ jobs:
     name: xcode (${{ matrix.label }})
     needs: should-run
     if: ${{ needs.should-run.outputs.should-run == 'true' }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- Adds `timeout-minutes: 30` to the `xcode-matrix` job in `build-and-test.yml`
- Normal simulator builds finish in ~6 minutes; without a cap the default 6-hour GH Actions timeout lets a stuck runner (e.g. a hung iOS simulator) sit idle for hours

## Context

Noticed while investigating a stuck iOS simulator run ([#30335778941](https://github.com/elastic/apm-agent-ios/actions/runs/30335778941/job/90200316632)) that had been running for 44+ minutes while tvOS/watchOS jobs on identical runners completed in ~6 minutes. The job had no timeout, so it would have continued until GH's 6-hour default killed it.

## Test plan

- [ ] Verify the xcode-matrix jobs still pass (normal runs well under 30 minutes)
- [ ] Confirm a future stuck run is killed at the 30-minute mark rather than after 6 hours