### PR TITLE
fix: align OTLP transport defaults

### DIFF
--- a/Sources/Tests/LinuxMain.swift
+++ b/Sources/Tests/LinuxMain.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-import apm_agent_iosTests
-
-var tests = [XCTestCaseEntry]()
-tests += apm_agent_iosTests.allTests()
-XCTMain(tests)

--- a/Sources/Tests/apm-agent-iosTests/AgentConfigurationTest.swift
+++ b/Sources/Tests/apm-agent-iosTests/AgentConfigurationTest.swift
@@ -13,66 +13,187 @@
 //   limitations under the License.
 
 import Foundation
-
 import XCTest
 @testable import ElasticApm
 
+final class AgentConfigurationTest: XCTestCase {
+  func testBuildWithoutAnEndpointIsNonThrowingAndReportsTheStableDiagnostic() {
+    let configuration: AgentConfiguration = AgentConfigBuilder().build()
 
-class AgentConfigurationTest : XCTestCase {
-  func testBasicConfiguration() {
-    let agentConfiguration = AgentConfigBuilder()
-      .withServerUrl(URL(string: "https://localhost:443")!)
-      .build()
-    XCTAssertEqual(agentConfiguration.collectorHost, "localhost")
-    XCTAssertEqual(agentConfiguration.collectorPort, 443)
-    XCTAssertEqual(agentConfiguration.collectorTLS, true)
-    XCTAssertEqual(agentConfiguration.connectionType, .grpc)
+    let resolution = configuration.resolveExportEndpoint()
+    XCTAssertNil(resolution.url)
+    XCTAssertNil(resolution.warning)
+    XCTAssertEqual(
+      resolution.validationMessage,
+      AgentConfiguration.exportEndpointValidationMessage
+    )
   }
 
-  func testEDOTUrls() {
-    let agentConfiguration = AgentConfigBuilder()
-      .withExportUrl(URL(string:"https://localhost:443")!)
-      .withManagementUrl(URL(string:"https://management.com:8200/v1/management")!)
-      .build()
-    let managementUrlComponents = agentConfiguration.managementUrlComponents()
-    XCTAssertEqual(managementUrlComponents.host, "management.com")
-    XCTAssertEqual(managementUrlComponents.port, 8200)
-    XCTAssertEqual(managementUrlComponents.path, "/v1/management")
-    XCTAssertEqual(managementUrlComponents.scheme, "https")
-    XCTAssertEqual(agentConfiguration.collectorHost, "localhost")
-    XCTAssertEqual(agentConfiguration.collectorPort, 443)
-    XCTAssertEqual(agentConfiguration.collectorTLS, true)
-    XCTAssertEqual(agentConfiguration.connectionType, .grpc)
+  func testInvalidEndpointsReportTheStableDiagnostic() {
+    let invalidUrls = [
+      URL(string: "relative/path")!,
+      URL(string: "ftp://collector.example.com")!,
+      URL(string: "https:///v1/traces")!,
+      URL(string: "https://collector.example.com:0")!,
+      URL(string: "https://collector.example.com:65536")!
+    ]
+
+    for invalidUrl in invalidUrls {
+      let resolution = AgentConfigBuilder()
+        .withExportUrl(invalidUrl)
+        .build()
+        .resolveExportEndpoint()
+      XCTAssertNil(resolution.url, "\(invalidUrl) must be rejected")
+      XCTAssertEqual(
+        resolution.validationMessage,
+        AgentConfiguration.exportEndpointValidationMessage
+      )
+    }
   }
 
- func testEDOTUrlAndNoManagementUrl() {
-    let agentConfiguration = AgentConfigBuilder()
-      .withExportUrl(URL(string:"https://localhost:443")!)
+  func testValidURLsPreservePathAndPortAndDeriveTLSFromScheme() {
+    let http = URL(string: "http://collector.example.com:4318/otlp")!
+    let https = URL(string: "https://collector.example.com:8443/otlp")!
+
+    let httpConfiguration = AgentConfigBuilder().withExportUrl(http).build()
+    XCTAssertEqual(httpConfiguration.resolveExportEndpoint().url, http)
+    XCTAssertEqual(OpenTelemetryHelper.getURL(with: httpConfiguration), http)
+    XCTAssertFalse(httpConfiguration.collectorTLS)
+    XCTAssertEqual(httpConfiguration.collectorPort, 4318)
+    XCTAssertEqual(httpConfiguration.collectorPath, "/otlp")
+
+    let httpsConfiguration = AgentConfigBuilder().withExportUrl(https).build()
+    XCTAssertEqual(httpsConfiguration.resolveExportEndpoint().url, https)
+    XCTAssertEqual(OpenTelemetryHelper.getURL(with: httpsConfiguration), https)
+    XCTAssertTrue(httpsConfiguration.collectorTLS)
+    XCTAssertEqual(httpsConfiguration.collectorPort, 8443)
+    XCTAssertEqual(httpsConfiguration.collectorPath, "/otlp")
+  }
+
+  func testOmittedPortsAreDerivedFromTheURLScheme() {
+    let http = AgentConfigBuilder()
+      .withExportUrl(URL(string: "http://collector.example.com")!)
+      .build()
+    let https = AgentConfigBuilder()
+      .withExportUrl(URL(string: "https://collector.example.com")!)
       .build()
 
-   XCTAssertEqual(agentConfiguration.managementUrlComponents().url, URL(string:"https://localhost:443/config/v1/agents"))
-    XCTAssertEqual(agentConfiguration.collectorHost, "localhost")
-    XCTAssertEqual(agentConfiguration.collectorPort, 443)
-   XCTAssertEqual(agentConfiguration.collectorTLS, true)
- }
+    XCTAssertEqual(http.collectorPort, 80)
+    XCTAssertFalse(http.collectorTLS)
+    XCTAssertEqual(https.collectorPort, 443)
+    XCTAssertTrue(https.collectorTLS)
+  }
 
-  func testEDOTUrlsWithDeprecatedServerUrl() {
-    let agentConfiguration = AgentConfigBuilder()
-      .withServerUrl(URL(string:"http://127.0.0.1:8080")!)
-      .withExportUrl(URL(string:"https://localhost:443")!)
-      .withManagementUrl(URL(string:"https://management.com:8200/v1/management")!)
+  func testHTTPIsTheDefaultConnectionTypeAndGrpcRemainsAnOptIn() {
+    XCTAssertEqual(AgentConfigBuilder().build().connectionType, .http)
+    XCTAssertEqual(
+      AgentConfigBuilder().useConnectionType(.grpc).build().connectionType,
+      .grpc
+    )
+  }
+
+  func testDeprecatedServerURLRemainsCompatibleAndExportURLTakesPrecedence() {
+    let serverUrl = URL(string: "http://legacy.example.com:4317")!
+    let exportUrl = URL(string: "https://export.example.com:4318/v1")!
+
+    let serverOnly = AgentConfigBuilder().withServerUrl(serverUrl).build()
+    XCTAssertEqual(serverOnly.resolveExportEndpoint().url, serverUrl)
+
+    let configuration = AgentConfigBuilder()
+      .withServerUrl(serverUrl)
+      .withExportUrl(exportUrl)
       .build()
+    XCTAssertEqual(configuration.resolveExportEndpoint().url, exportUrl)
+    XCTAssertEqual(
+      configuration.managementUrlComponents().url,
+      URL(string: "https://export.example.com:4318/v1/config/v1/agents")
+    )
+  }
 
-    let managementUrlComponents = agentConfiguration.managementUrlComponents()
-    XCTAssertEqual(managementUrlComponents.host, "management.com")
-    XCTAssertEqual(managementUrlComponents.port, 8200)
-    XCTAssertEqual(managementUrlComponents.path, "/v1/management")
-    XCTAssertEqual(managementUrlComponents.scheme, "https")
-    XCTAssertEqual(agentConfiguration.collectorHost, "localhost")
-    XCTAssertEqual(agentConfiguration.collectorPort, 443)
-    XCTAssertEqual(agentConfiguration.collectorTLS, true)
-    XCTAssertEqual(agentConfiguration.connectionType, .grpc)
+  func testDeprecatedEndpointPropertiesRemainAssignableAndAdaptLiveValues() {
+    var configuration = AgentConfigBuilder().build()
+    configuration.collectorHost = "legacy.example.com"
+    configuration.collectorPath = "/ingest"
+    configuration.collectorPort = 4318
+    configuration.collectorTLS = true
+
+    let resolution = configuration.resolveExportEndpoint()
+    XCTAssertEqual(
+      resolution.url,
+      URL(string: "https://legacy.example.com:4318/ingest")
+    )
+    XCTAssertEqual(
+      resolution.warning,
+      AgentConfiguration.deprecatedEndpointMigrationWarning
+    )
+    XCTAssertNil(resolution.validationMessage)
+  }
+
+  func testPartialDeprecatedEndpointChangesUseTheCompatibilityDefaults() {
+    var configuration = AgentConfigBuilder().build()
+    configuration.collectorPath = "/ingest"
+
+    let resolution = configuration.resolveExportEndpoint()
+    XCTAssertEqual(
+      resolution.url,
+      URL(string: "http://127.0.0.1:8200/ingest")
+    )
+    XCTAssertEqual(
+      resolution.warning,
+      AgentConfiguration.deprecatedEndpointMigrationWarning
+    )
+  }
+
+  func testFullURLProjectionIsNotTreatedAsDeprecatedPropertyMutation() {
+    let exportUrl = URL(string: "https://collector.example.com:8443/otlp")!
+    let configuration = AgentConfigBuilder().withExportUrl(exportUrl).build()
+
+    let resolution = configuration.resolveExportEndpoint()
+    XCTAssertEqual(resolution.url, exportUrl)
+    XCTAssertNil(resolution.warning)
+  }
+
+  func testFullURLWinsAfterDeprecatedEndpointPropertyMutation() {
+    let exportUrl = URL(string: "https://collector.example.com:8443/otlp")!
+    var configuration = AgentConfigBuilder()
+      .withExportUrl(exportUrl)
+      .useConnectionType(.grpc)
+      .build()
+    configuration.collectorHost = "ignored.example.com"
+    configuration.collectorPath = "/ignored"
+    configuration.collectorPort = 4317
+    configuration.collectorTLS = false
+
+    let resolution = configuration.resolveExportEndpoint()
+    XCTAssertEqual(resolution.url, exportUrl)
+    XCTAssertEqual(configuration.connectionType, .grpc)
+    XCTAssertEqual(
+      resolution.warning,
+      AgentConfiguration.ignoredDeprecatedEndpointMutationWarning
+    )
+    XCTAssertEqual(OpenTelemetryHelper.getURL(with: configuration), exportUrl)
+    XCTAssertEqual(
+      configuration.managementUrlComponents().url,
+      URL(string: "https://collector.example.com:8443/otlp/config/v1/agents")
+    )
+  }
+
+  func testInvalidFullURLDoesNotFallBackToDeprecatedEndpointProperties() {
+    var configuration = AgentConfigBuilder()
+      .withExportUrl(URL(string: "ftp://collector.example.com")!)
+      .build()
+    configuration.collectorHost = "legacy.example.com"
+    configuration.collectorPort = 4318
+
+    let resolution = configuration.resolveExportEndpoint()
+    XCTAssertNil(resolution.url)
+    XCTAssertEqual(
+      resolution.warning,
+      AgentConfiguration.ignoredDeprecatedEndpointMutationWarning
+    )
+    XCTAssertEqual(
+      resolution.validationMessage,
+      AgentConfiguration.exportEndpointValidationMessage
+    )
   }
 }
-
-

--- a/Sources/Tests/apm-agent-iosTests/AgentConfigurationTest.swift
+++ b/Sources/Tests/apm-agent-iosTests/AgentConfigurationTest.swift
@@ -110,6 +110,17 @@ final class AgentConfigurationTest: XCTestCase {
     )
   }
 
+  func testManagementURLDoesNotDuplicateTrailingPathSeparator() {
+    let configuration = AgentConfigBuilder()
+      .withExportUrl(URL(string: "https://export.example.com:4318/otlp/")!)
+      .build()
+
+    XCTAssertEqual(
+      configuration.managementUrlComponents().url,
+      URL(string: "https://export.example.com:4318/otlp/config/v1/agents")
+    )
+  }
+
   func testDeprecatedEndpointPropertiesRemainAssignableAndAdaptLiveValues() {
     var configuration = AgentConfigBuilder().build()
     configuration.collectorHost = "legacy.example.com"

--- a/Sources/Tests/apm-agent-iosTests/XCTestManifests.swift
+++ b/Sources/Tests/apm-agent-iosTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-    public func allTests() -> [XCTestCaseEntry] {
-        return [
-            testCase(apm_agent_iosTests.allTests)
-        ]
-    }
-#endif

--- a/Sources/Tests/apm-agent-iosTests/apm_agent_iosTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/apm_agent_iosTests.swift
@@ -2,15 +2,27 @@
 import XCTest
 
 final class apm_agent_iosTests: XCTestCase {
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-//        XCTAssertEqual(apm_agent_ios().text, "Hello, World!")
-        ElasticApmAgent.start()
-    }
+  func testEnabledInvalidConfigurationDoesNotInitializeTheAgent() {
+    let configuration = AgentConfigBuilder()
+      .withExportUrl(URL(string: "ftp://collector.example.com")!)
+      .build()
 
-    static var allTests = [
-        ("testExample", testExample)
-    ]
+    ElasticApmAgent.start(with: configuration)
+
+    XCTAssertNil(ElasticApmAgent.shared())
+  }
+
+  func testDisabledConfigurationReturnsBeforeEndpointValidation() {
+    let configuration = AgentConfigBuilder().disableAgent().build()
+
+    ElasticApmAgent.start(with: configuration)
+
+    XCTAssertNil(ElasticApmAgent.shared())
+  }
+
+  func testDeprecatedNoArgumentStartDoesNotInitializeTheAgent() {
+    ElasticApmAgent.start()
+
+    XCTAssertNil(ElasticApmAgent.shared())
+  }
 }

--- a/Sources/Tests/apm-agent-iosTests/utils/OpenTelemetryHelperTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/utils/OpenTelemetryHelperTests.swift
@@ -1,5 +1,4 @@
-//
-//  Copyright © 2025  Elasticsearch BV
+// Copyright © 2025  Elasticsearch BV
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -15,51 +14,63 @@
 
 import Foundation
 import XCTest
-import OpenTelemetrySdk
 @testable import ElasticApm
 
-class OpenTelemetryHelperTests : XCTestCase {
-  func testGetURL() {
-    let simpleHttp = URL(string:"http://localhost")!
-    XCTAssertEqual(
-      simpleHttp,
-      OpenTelemetryHelper.getURL(with: AgentConfigBuilder().withExportUrl(simpleHttp).build())
-    )
-    let portHttp = URL(string: "http://localhost:8200")!
-    XCTAssertEqual(
-      portHttp,
-      OpenTelemetryHelper.getURL(with: AgentConfigBuilder().withExportUrl(portHttp).build())
-    )
+final class OpenTelemetryHelperTests: XCTestCase {
+  func testUsesTheCanonicalFullURL() {
+    let endpoints = [
+      URL(string: "http://collector.example.com")!,
+      URL(string: "http://collector.example.com:4318/unique/path")!,
+      URL(string: "https://collector.example.com:8443/unique/path")!
+    ]
 
-    let pathHttp = URL(string: "http://localhost/unique/path")!
-    XCTAssertEqual(
-      pathHttp,
-      OpenTelemetryHelper.getURL(with: AgentConfigBuilder().withExportUrl(pathHttp).build())
-    )
+    for endpoint in endpoints {
+      let configuration = AgentConfigBuilder().withExportUrl(endpoint).build()
+      XCTAssertEqual(OpenTelemetryHelper.getURL(with: configuration), endpoint)
+    }
+  }
 
-    let portPathHttp = URL(string: "http://localhost:8200/unique/path")!
-    XCTAssertEqual(
-      portPathHttp,
-      OpenTelemetryHelper.getURL(with: AgentConfigBuilder().withExportUrl(portPathHttp).build())
-    )
+  func testDoesNotActivateUntouchedCompatibilityDefaults() {
+    XCTAssertNil(OpenTelemetryHelper.getURL(with: AgentConfigBuilder().build()))
+  }
 
-    let portPathHttps = URL(string: "https://localhost:8200/unique/path")!
-    XCTAssertEqual(
-      portPathHttps,
-      OpenTelemetryHelper.getURL(with: AgentConfigBuilder().withExportUrl(portPathHttps).build())
-    )
+  func testChannelTargetUsesTheCanonicalEndpoint() {
+    let endpoints = [
+      (
+        URL(string: "http://collector.example.com:4318")!,
+        GrpcChannelTarget(host: "collector.example.com", port: 4318, useTLS: false)
+      ),
+      (
+        URL(string: "https://collector.example.com:8443")!,
+        GrpcChannelTarget(host: "collector.example.com", port: 8443, useTLS: true)
+      ),
+      (
+        URL(string: "https://collector.example.com")!,
+        GrpcChannelTarget(host: "collector.example.com", port: 443, useTLS: true)
+      )
+    ]
 
-    let defaultPortHttps = URL(string: "https://localhost:443/unique/path")!
-    XCTAssertEqual(
-      URL(string: "https://localhost/unique/path")!,
-      OpenTelemetryHelper.getURL(with: AgentConfigBuilder().withExportUrl(defaultPortHttps).build())
-    )
+    for (endpoint, expectedTarget) in endpoints {
+      let configuration = AgentConfigBuilder()
+        .withExportUrl(endpoint)
+        .useConnectionType(.grpc)
+        .build()
+      XCTAssertEqual(OpenTelemetryHelper.channelTarget(with: configuration), expectedTarget)
+    }
+  }
 
-    let defaultExportUrl = URL(string: "http://127.0.0.1:8200")
-    XCTAssertEqual(
-      defaultExportUrl,
-      OpenTelemetryHelper.getURL(with: AgentConfigBuilder().build())
-    )
+  func testChannelTargetIgnoresDeprecatedMutationsAfterAFullURL() {
+    var configuration = AgentConfigBuilder()
+      .withExportUrl(URL(string: "https://canonical.example.com:8443")!)
+      .useConnectionType(.grpc)
+      .build()
+    configuration.collectorHost = "ignored.example.com"
+    configuration.collectorPort = 4317
+    configuration.collectorTLS = false
 
+    XCTAssertEqual(
+      OpenTelemetryHelper.channelTarget(with: configuration),
+      GrpcChannelTarget(host: "canonical.example.com", port: 8443, useTLS: true)
+    )
   }
 }

--- a/Sources/apm-agent-ios/AgentConfigBuilder.swift
+++ b/Sources/apm-agent-ios/AgentConfigBuilder.swift
@@ -19,7 +19,7 @@ import PersistenceExporter
 
 public class AgentConfigBuilder {
   private var enableAgent: Bool?
-  private var url: URL?
+  private var serverUrl: URL?
   private var exportUrl: URL?
   private var managementUrl: URL?
   private var enableRemoteManagement: Bool = true
@@ -27,7 +27,7 @@ public class AgentConfigBuilder {
   private var enableOpAPM: Bool = false
   private static let bearer = "Bearer"
   private static let api = "ApiKey"
-  private var connectionType: AgentConnectionType = .grpc
+  private var connectionType: AgentConnectionType = .http
   private var sampleRate = 1.0
 
   private var spanFilters = [SignalFilter<ReadableSpan>]()
@@ -42,10 +42,14 @@ public class AgentConfigBuilder {
     return self
   }
 
-  @available(*, deprecated, renamed: "withExportUrl",
-             message: "Export and config management URLs will be seperated in future.")
+  @available(
+    *,
+    deprecated,
+    renamed: "withExportUrl",
+    message: "Use withExportUrl(_:) for OTLP export and withManagementUrl(_:) for management."
+  )
   public func withServerUrl(_ url: URL) -> Self {
-    self.url = url
+    self.serverUrl = url
     return self
   }
 
@@ -135,31 +139,18 @@ public class AgentConfigBuilder {
       }
     }
 
-    let url = self.exportUrl ?? self.url
-    if let url {
-      if let proto = url.scheme, proto == "https" {
-        config.collectorTLS = true
-      }
-      if let host = url.host {
-        config.collectorHost = host
-      }
-      if let port = url.port {
-        config.collectorPort = port
-      } else {
-        config.collectorPort = config.collectorTLS ? 443 : 80
-      }
-
-      config.collectorPath = url.path
-
-      if let auth = self.auth {
-        config.auth = auth
-      }
+    let endpointUrl = self.exportUrl ?? self.serverUrl
+    config.setFullExportUrl(endpointUrl)
+    if let endpointUrl {
+      config.projectFullExportUrl(endpointUrl)
     }
 
-    if let enableAgent = enableAgent {
+    if let auth = self.auth {
+      config.auth = auth
+    }
+    if let enableAgent = self.enableAgent {
       config.enableAgent = enableAgent
     }
-
     config.enableOpAMP = enableOpAPM
     return config
   }

--- a/Sources/apm-agent-ios/AgentConfiguration.swift
+++ b/Sources/apm-agent-ios/AgentConfiguration.swift
@@ -166,7 +166,7 @@ public struct AgentConfiguration {
     components.path =
       (path.isEmpty || path == "/")
       ? "/config/v1/agents"
-      : "\(path)/config/v1/agents"
+      : "\(path.hasSuffix("/") ? String(path.dropLast()) : path)/config/v1/agents"
     return components
   }
 

--- a/Sources/apm-agent-ios/AgentConfiguration.swift
+++ b/Sources/apm-agent-ios/AgentConfiguration.swift
@@ -3,22 +3,92 @@ import OpenTelemetryApi
 import OpenTelemetrySdk
 import PersistenceExporter
 
-public enum AgentConnectionType {
+public enum AgentConnectionType: Equatable {
   case grpc
   case http
 }
 
+struct ExportEndpointResolution {
+  let url: URL?
+  let warning: String?
+  let validationMessage: String?
+}
+
 public struct AgentConfiguration {
+  static let exportEndpointValidationMessage =
+    "Failed to start EDOT iOS: provide an explicit OTLP export URL with an http or https scheme and a host."
+  static let deprecatedEndpointMigrationWarning =
+    "Warning: collectorHost, collectorPath, collectorPort, and collectorTLS are deprecated; configure the endpoint with AgentConfigBuilder.withExportUrl(_:) instead."
+  static let ignoredDeprecatedEndpointMutationWarning =
+    "Warning: deprecated collector endpoint field changes were ignored because a full export URL was supplied."
+
   init() {}
   public var enableAgent = true
   public var enableRemoteManagement = true
   public var enableOpAMP = false
   public var managementUrl: URL?
-  public var collectorHost = "127.0.0.1"
-  public var collectorPath = ""
-  public var collectorPort = 8200
-  public var collectorTLS = false
-  public var connectionType: AgentConnectionType = .grpc
+
+  private var legacyCollectorHost = "127.0.0.1"
+  private var legacyCollectorPath = ""
+  private var legacyCollectorPort = 8200
+  private var legacyCollectorTLS = false
+  private var deprecatedEndpointPropertiesWereMutated = false
+  private var fullExportUrl: URL?
+  var resolvedExportUrl: URL?
+
+  @available(
+    *,
+    deprecated,
+    message: "Configure the endpoint with AgentConfigBuilder.withExportUrl(_:) instead."
+  )
+  public var collectorHost: String {
+    get { legacyCollectorHost }
+    set {
+      legacyCollectorHost = newValue
+      deprecatedEndpointPropertiesWereMutated = true
+    }
+  }
+
+  @available(
+    *,
+    deprecated,
+    message: "Configure the endpoint with AgentConfigBuilder.withExportUrl(_:) instead."
+  )
+  public var collectorPath: String {
+    get { legacyCollectorPath }
+    set {
+      legacyCollectorPath = newValue
+      deprecatedEndpointPropertiesWereMutated = true
+    }
+  }
+
+  @available(
+    *,
+    deprecated,
+    message: "Configure the endpoint with AgentConfigBuilder.withExportUrl(_:) instead."
+  )
+  public var collectorPort: Int {
+    get { legacyCollectorPort }
+    set {
+      legacyCollectorPort = newValue
+      deprecatedEndpointPropertiesWereMutated = true
+    }
+  }
+
+  @available(
+    *,
+    deprecated,
+    message: "Configure the endpoint with AgentConfigBuilder.withExportUrl(_:) instead."
+  )
+  public var collectorTLS: Bool {
+    get { legacyCollectorTLS }
+    set {
+      legacyCollectorTLS = newValue
+      deprecatedEndpointPropertiesWereMutated = true
+    }
+  }
+
+  public var connectionType: AgentConnectionType = .http
   var auth: String?
   var sampleRate: Double = 1.0
 
@@ -28,25 +98,98 @@ public struct AgentConfiguration {
   var spanAttributeInterceptor: any Interceptor<[String: AttributeValue]> = NoopInterceptor<[String: AttributeValue]>()
   var logRecordAttributeInterceptor: any Interceptor<[String: AttributeValue]> = NoopInterceptor<[String: AttributeValue]>()
 
-  public func managementUrlComponents() -> URLComponents {
-    var components = URLComponents()
-    if let managementUrl {
-      components.scheme = managementUrl.scheme
-      components.host = managementUrl.host
-      components.path = managementUrl.path
-      components.port = managementUrl.port
-      return components
-    } else {
+  mutating func setFullExportUrl(_ url: URL?) {
+    fullExportUrl = url
+  }
 
-      if collectorTLS {
-        components.scheme = "https"
-      } else {
-        components.scheme = "http"
-      }
-      components.host = collectorHost
-      components.port = collectorPort
-      components.path = collectorPath + "/config/v1/agents"
-      return components
+  mutating func projectFullExportUrl(_ url: URL) {
+    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    legacyCollectorTLS = components?.scheme?.lowercased() == "https"
+    if let host = components?.host {
+      legacyCollectorHost = host
     }
+    if let port = components?.port {
+      legacyCollectorPort = port
+    } else {
+      legacyCollectorPort = legacyCollectorTLS ? 443 : 80
+    }
+    legacyCollectorPath = components?.path ?? url.path
+  }
+
+  func resolveExportEndpoint() -> ExportEndpointResolution {
+    if let fullExportUrl {
+      let warning =
+        deprecatedEndpointPropertiesWereMutated
+        ? Self.ignoredDeprecatedEndpointMutationWarning
+        : nil
+      return Self.validate(fullExportUrl, warning: warning)
+    }
+
+    guard deprecatedEndpointPropertiesWereMutated else {
+      return ExportEndpointResolution(
+        url: nil,
+        warning: nil,
+        validationMessage: Self.exportEndpointValidationMessage
+      )
+    }
+
+    var components = URLComponents()
+    components.scheme = legacyCollectorTLS ? "https" : "http"
+    components.host = legacyCollectorHost
+    components.port = legacyCollectorPort
+    components.path = legacyCollectorPath
+    return Self.validate(
+      components.url,
+      warning: Self.deprecatedEndpointMigrationWarning
+    )
+  }
+
+  mutating func setResolvedExportUrl(_ url: URL) {
+    resolvedExportUrl = url
+  }
+
+  public func managementUrlComponents() -> URLComponents {
+    if let managementUrl {
+      return URLComponents(url: managementUrl, resolvingAgainstBaseURL: false)
+        ?? URLComponents()
+    }
+
+    guard let exportUrl = resolvedExportUrl ?? resolveExportEndpoint().url else {
+      return URLComponents()
+    }
+
+    var components = URLComponents()
+    components.scheme = exportUrl.scheme
+    components.host = exportUrl.host
+    components.port = exportUrl.port
+    let path = exportUrl.path
+    components.path =
+      (path.isEmpty || path == "/")
+      ? "/config/v1/agents"
+      : "\(path)/config/v1/agents"
+    return components
+  }
+
+  private static func validate(
+    _ url: URL?,
+    warning: String?
+  ) -> ExportEndpointResolution {
+    guard
+      let url,
+      let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+      let scheme = components.scheme?.lowercased(),
+      scheme == "http" || scheme == "https",
+      let host = components.host,
+      !host.isEmpty,
+      components.port.map({ (1 ... 65_535).contains($0) }) ?? true
+    else {
+      return ExportEndpointResolution(
+        url: nil,
+        warning: warning,
+        validationMessage: exportEndpointValidationMessage
+      )
+    }
+
+    return ExportEndpointResolution(url: url, warning: warning, validationMessage: nil)
   }
 }

--- a/Sources/apm-agent-ios/ElasticApmAgent.swift
+++ b/Sources/apm-agent-ios/ElasticApmAgent.swift
@@ -16,10 +16,24 @@ public class ElasticApmAgent {
     with configuration: AgentConfiguration,
     _ instrumentationConfiguration: InstrumentationConfiguration = InstrumentationConfiguration()
   ) {
+    var configuration = configuration
     if !configuration.enableAgent {
       os_log("Elastic APM Agent has been disabled.")
       return
     }
+    let endpointResolution = configuration.resolveExportEndpoint()
+    if let warning = endpointResolution.warning {
+      os_log("%{public}@", type: .default, warning)
+    }
+    guard let endpoint = endpointResolution.url else {
+      os_log(
+        "%{public}@",
+        type: .error,
+        endpointResolution.validationMessage ?? AgentConfiguration.exportEndpointValidationMessage
+      )
+      return
+    }
+    configuration.setResolvedExportUrl(endpoint)
     #if !os(watchOS)
     Kronos.Clock.sync()
     #endif
@@ -28,6 +42,11 @@ public class ElasticApmAgent {
       configuration: configuration, instrumentationConfiguration: instrumentationConfiguration)
   }
 
+  @available(
+    *,
+    deprecated,
+    message: "Build a configuration with AgentConfigBuilder.withExportUrl(_:) and call ElasticApmAgent.start(with:)."
+  )
   public static func start() {
     ElasticApmAgent.start(with: AgentConfiguration())
   }

--- a/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
+++ b/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
@@ -71,7 +71,10 @@ class OpenTelemetryInitializer {
     let otlpConfiguration = OtlpConfiguration(
       timeout: OtlpConfiguration.DefaultTimeoutInterval,
       headers: OpenTelemetryHelper.generateExporterHeaders(configuration.agent.auth))
-    let channel = OpenTelemetryHelper.getChannel(with: configuration.agent, group: group)
+    guard let channelTarget = OpenTelemetryHelper.channelTarget(with: configuration.agent) else {
+      return NoopLogRecordExporter.instance
+    }
+    let channel = OpenTelemetryHelper.makeChannel(target: channelTarget, group: group)
 
     let resources = AgentResource.get().merging(other: AgentEnvResource.get())
     let metricExporter = {

--- a/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
+++ b/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
@@ -72,6 +72,11 @@ class OpenTelemetryInitializer {
       timeout: OtlpConfiguration.DefaultTimeoutInterval,
       headers: OpenTelemetryHelper.generateExporterHeaders(configuration.agent.auth))
     guard let channelTarget = OpenTelemetryHelper.channelTarget(with: configuration.agent) else {
+      os_log(
+        "%{public}@",
+        type: .error,
+        AgentConfiguration.exportEndpointValidationMessage
+      )
       return NoopLogRecordExporter.instance
     }
     let channel = OpenTelemetryHelper.makeChannel(target: channelTarget, group: group)

--- a/Sources/apm-agent-ios/Utils/OpenTelemetryHelper.swift
+++ b/Sources/apm-agent-ios/Utils/OpenTelemetryHelper.swift
@@ -19,6 +19,33 @@ import ResourceExtension
 import GRPC
 import NIO
 
+struct GrpcChannelTarget: Equatable {
+  let host: String
+  let port: Int
+  let useTLS: Bool
+
+  init(host: String, port: Int, useTLS: Bool) {
+    self.host = host
+    self.port = port
+    self.useTLS = useTLS
+  }
+
+  init?(endpoint: URL) {
+    guard
+      let host = endpoint.host,
+      let scheme = endpoint.scheme?.lowercased(),
+      scheme == "http" || scheme == "https",
+      endpoint.port.map({ (1 ... 65_535).contains($0) }) ?? true
+    else {
+      return nil
+    }
+
+    self.host = host
+    useTLS = scheme == "https"
+    port = endpoint.port ?? (useTLS ? 443 : 80)
+  }
+}
+
 public class OpenTelemetryHelper {
     struct Headers {
         static let userAgent = "User-Agent"
@@ -49,27 +76,41 @@ public class OpenTelemetryHelper {
     }
 
   public static func getURL(with config: AgentConfiguration) -> URL? {
-
-    var port = "\(config.collectorPort)"
-    if config.collectorPort == 80 || config.collectorPort == 443 {
-      port = ""
-    }
-
-    return URL(
-      string: "\(config.collectorTLS ? "https://" : "http://")\(config.collectorHost)\( port.isEmpty ? "" : ":\(port)")\(config.collectorPath)"
-    )
-
+    config.resolvedExportUrl ?? config.resolveExportEndpoint().url
   }
 
-    public static func getChannel(with config: AgentConfiguration, group: EventLoopGroup) -> ClientConnection {
-
-        if config.collectorTLS {
-             return ClientConnection.usingPlatformAppropriateTLS(for: group)
-                 .connect(host: config.collectorHost, port: config.collectorPort)
-         } else {
-              return ClientConnection.insecure(group: group)
-                 .connect(host: config.collectorHost, port: config.collectorPort)
-         }
-
+  static func channelTarget(with config: AgentConfiguration) -> GrpcChannelTarget? {
+    guard let endpoint = getURL(with: config) else {
+      return nil
     }
+    return GrpcChannelTarget(endpoint: endpoint)
+  }
+
+  static func makeChannel(
+    target: GrpcChannelTarget,
+    group: EventLoopGroup
+  ) -> ClientConnection {
+    if target.useTLS {
+      return ClientConnection.usingPlatformAppropriateTLS(for: group)
+        .connect(host: target.host, port: target.port)
+    }
+    return ClientConnection.insecure(group: group)
+      .connect(host: target.host, port: target.port)
+  }
+
+  @available(
+    *,
+    deprecated,
+    message: "Start telemetry with ElasticApmAgent.start(with:) instead."
+  )
+  public static func getChannel(
+    with config: AgentConfiguration,
+    group: EventLoopGroup
+  ) -> ClientConnection {
+    guard let target = channelTarget(with: config) else {
+      preconditionFailure(AgentConfiguration.exportEndpointValidationMessage)
+    }
+
+    return makeChannel(target: target, group: group)
+  }
 }

--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -106,7 +106,7 @@ integrations; configure the full endpoint with
 Existing integrations can temporarily mutate one or more of these properties
 after `build()`. When no full export URL is supplied, EDOT iOS synthesizes an
 HTTP(S) endpoint from their live values and logs a migration warning. When a
-full export URL was supplied, it remains authoritative, the mutations are
+full export URL is supplied, it remains authoritative, the mutations are
 ignored, and EDOT iOS logs an ignored-mutation warning.
 
 ### Authentication [authentication]

--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -104,7 +104,7 @@ integrations; configure the full endpoint with
 `ElasticApmAgent.start(with:)` instead.
 
 Existing integrations can temporarily mutate one or more of these properties
-after `build()`. When no full export URL was supplied, EDOT iOS synthesizes an
+after `build()`. When no full export URL is supplied, EDOT iOS synthesizes an
 HTTP(S) endpoint from their live values and logs a migration warning. When a
 full export URL was supplied, it remains authoritative, the mutations are
 ignored, and EDOT iOS logs an ignored-mutation warning.

--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -99,7 +99,7 @@ It remains temporarily source compatible; when both URL methods are called,
 
 `AgentConfiguration.collectorHost`, `collectorPath`, `collectorPort`, and
 `collectorTLS` are deprecated compatibility properties. Do not use them for new
-integrations; configure the full endpoint with
+integrations. Configure the full endpoint with
 [`withExportUrl(_:)`](#withExportUrl) and start with
 `ElasticApmAgent.start(with:)` instead.
 

--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -32,7 +32,6 @@ import Foundation
 let configuration = AgentConfigBuilder()
   .withExportUrl(URL(string: "https://your-otlp-endpoint")!)
   .withApiKey("your-api-key")
-  .useConnectionType(.http)
   .build()
 
 ElasticApmAgent.start(with: configuration)
@@ -45,12 +44,10 @@ Configure where EDOT iOS exports telemetry and which OTLP transport it uses:
 ```swift
 let configuration = AgentConfigBuilder()
   .withExportUrl(URL(string: "https://collector.example.com:4318")!) // <1>
-  .useConnectionType(.http) // <2>
   .build()
 ```
 
 1. The base endpoint that receives OTLP data.
-2. The OTLP transport. Use `.http` for OTLP/HTTP or `.grpc` for OTLP/gRPC.
 
 #### `withExportUrl(_:)` [withExportUrl]
 
@@ -58,7 +55,8 @@ let configuration = AgentConfigBuilder()
 | --- | --- |
 | `URL` | Yes |
 
-Sets the OTLP endpoint provided by an Elastic Agent or EDOT Collector gateway.
+Sets the required OTLP endpoint provided by an Elastic Agent or EDOT Collector gateway.
+An enabled agent does not start without a valid `http` or `https` URL with a host.
 
 When the connection type is `.http`, EDOT iOS appends `/v1/traces`, `/v1/metrics`, or `/v1/logs` to the configured path for each signal. When the connection type is `.grpc`, all signals use the configured gRPC endpoint.
 
@@ -66,14 +64,18 @@ When the connection type is `.http`, EDOT iOS appends `/v1/traces`, `/v1/metrics
 
 | Type | Default |
 | --- | --- |
-| `AgentConnectionType` | `.grpc` |
+| `AgentConnectionType` | `.http` |
 
 Selects the OTLP transport:
 
 - `.grpc` uses the OTLP/gRPC exporters.
 - `.http` uses the OTLP/HTTP exporters.
 
-Make sure the endpoint supports the selected transport. EDOT Collector commonly listens on port `4317` for gRPC and `4318` for HTTP.
+OTLP/HTTP is the default. Use `.useConnectionType(.grpc)` only when the OTLP
+endpoint requires gRPC. The export URL controls security: `https` enables TLS
+and `http` uses plaintext. Make sure the endpoint supports the selected
+transport. EDOT Collector commonly listens on port `4317` for gRPC and `4318`
+for HTTP.
 
 #### `withServerUrl(_:)` [withServerUrl]
 
@@ -86,7 +88,26 @@ product:
 | --- | --- |
 | `URL` | Not set |
 
-Sets a single URL host endpoint that handles both OTLP data export and central configuration. This option is deprecated: use [`withExportUrl(_:)`](#withExportUrl) for OTLP data export and [`withManagementUrl(_:)`](#withManagementUrl) for central configuration instead.
+Sets a single URL host endpoint that handles both OTLP data export and central configuration.
+This option is deprecated: do not use it for new integrations. Use
+[`withExportUrl(_:)`](#withExportUrl) for OTLP data export and
+[`withManagementUrl(_:)`](#withManagementUrl) for central configuration instead.
+It remains temporarily source compatible; when both URL methods are called,
+`withExportUrl(_:)` takes precedence.
+
+#### Deprecated split endpoint properties [deprecated-split-endpoint-properties]
+
+`AgentConfiguration.collectorHost`, `collectorPath`, `collectorPort`, and
+`collectorTLS` are deprecated compatibility properties. Do not use them for new
+integrations; configure the full endpoint with
+[`withExportUrl(_:)`](#withExportUrl) and start with
+`ElasticApmAgent.start(with:)` instead.
+
+Existing integrations can temporarily mutate one or more of these properties
+after `build()`. When no full export URL was supplied, EDOT iOS synthesizes an
+HTTP(S) endpoint from their live values and logs a migration warning. When a
+full export URL was supplied, it remains authoritative, the mutations are
+ignored, and EDOT iOS logs an ignored-mutation warning.
 
 ### Authentication [authentication]
 
@@ -180,6 +201,7 @@ Sets the probability that spans from a new session are sampled. A value of `1.0`
 
 ```swift
 let configuration = AgentConfigBuilder()
+  .withExportUrl(URL(string: "https://your-otlp-endpoint")!)
   .withSessionSampleRate(0.5)
   .build()
 ```
@@ -196,6 +218,7 @@ Adds a span filter:
 
 ```swift
 let configuration = AgentConfigBuilder()
+  .withExportUrl(URL(string: "https://your-otlp-endpoint")!)
   .addSpanFilter { span in
     span.name != "health-check"
   }
@@ -210,6 +233,7 @@ Adds a log record filter:
 
 ```swift
 let configuration = AgentConfigBuilder()
+  .withExportUrl(URL(string: "https://your-otlp-endpoint")!)
   .addLogFilter { logRecord in
     logRecord.severity != .trace
   }
@@ -237,6 +261,7 @@ let interceptor = ClosureInterceptor<[String: AttributeValue]> { attributes in
 }
 
 let configuration = AgentConfigBuilder()
+  .withExportUrl(URL(string: "https://your-otlp-endpoint")!)
   .addSpanAttributeInterceptor(interceptor)
   .build()
 ```
@@ -256,6 +281,7 @@ let interceptor = ClosureInterceptor<[String: AttributeValue]> { attributes in
 }
 
 let configuration = AgentConfigBuilder()
+  .withExportUrl(URL(string: "https://your-otlp-endpoint")!)
   .addLogRecordAttributeInterceptor(interceptor)
   .build()
 ```
@@ -276,7 +302,9 @@ let configuration = AgentConfigBuilder()
 ElasticApmAgent.start(with: configuration)
 ```
 
-Use this when you need to keep the dependency in your app but disable it for a build or environment.
+Use this when you need to keep the dependency in your app but disable it for a
+build or environment. Intentionally disabled configurations do not require an
+export URL because they do not initialize telemetry.
 
 ## Automatic instrumentation configuration [instrumentationConfiguration]
 

--- a/docs/reference/edot-ios/getting-started.md
+++ b/docs/reference/edot-ios/getting-started.md
@@ -82,15 +82,17 @@ import Foundation
 let configuration = AgentConfigBuilder()
   .withExportUrl(URL(string: "https://your-otlp-endpoint")!) // <1>
   .withApiKey("your-api-key") // <2>
-  .useConnectionType(.http) // <3>
   .build()
 
 ElasticApmAgent.start(with: configuration)
 ```
 
+OTLP/HTTP is the default transport. Use `.useConnectionType(.grpc)` only when
+your OTLP endpoint requires gRPC, usually on port `4317`. The URL scheme selects
+transport security: `https` enables TLS and `http` uses plaintext.
+
 1. Replace this value with your OTLP endpoint. For deployment options, refer to [OpenTelemetry ingest paths](docs-content://solutions/observability/apm/opentelemetry/index.md).
 2. Create an [APM agent key for EDOT SDKs](docs-content://solutions/observability/apm/opentelemetry/create-apm-agent-key-for-edot-sdks.md). You can use a [secret token](configuration.md#secretToken) instead when your deployment requires one.
-3. Use OTLP/HTTP for an HTTP endpoint, usually on port `4318`. Use `.grpc` for an OTLP/gRPC endpoint, usually on port `4317`.
 
 ### SwiftUI applications [swiftui-setup]
 
@@ -109,7 +111,6 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     let configuration = AgentConfigBuilder()
       .withExportUrl(URL(string: "https://your-otlp-endpoint")!)
       .withApiKey("your-api-key")
-      .useConnectionType(.http)
       .build()
 
     ElasticApmAgent.start(with: configuration)
@@ -146,7 +147,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     let configuration = AgentConfigBuilder()
       .withExportUrl(URL(string: "https://your-otlp-endpoint")!)
       .withApiKey("your-api-key")
-      .useConnectionType(.http)
       .build()
 
     ElasticApmAgent.start(with: configuration)


### PR DESCRIPTION
## Summary

Require an explicit OTLP export URL before starting an enabled agent, default exports to OTLP/HTTP, and derive transport security from the URL while preserving deprecated endpoint compatibility.

## Changes

- Resolve and validate export endpoints centrally, warning on deprecated split-field usage and stopping startup for missing or invalid URLs.
- Default to OTLP/HTTP while retaining explicit gRPC support, with behavior coverage for endpoint precedence and channel targets.
- Update setup and configuration guidance and remove obsolete manual test-discovery scaffolding.