### PR TITLE
docs: correct instrumentation documentation

### DIFF
--- a/Sources/apm-agent-ios/Instrumentation/README.md
+++ b/Sources/apm-agent-ios/Instrumentation/README.md
@@ -1,10 +1,5 @@
-# User Action Instrumentation
+# View Controller Instrumentation
 
-User action instrumentation consist of view controller instrumentation & tap instrumentation.
-These both capture actions in the form of spans from UIKit and from SwiftUI, but with some limitations. 
-
-
-## View Controller Insturmentation
 This instrumentation create a span on `viewWillAppear`/`viewDidLoad` and ends on `ViewDidAppear`.
 If multiple view controllers are loaded simultaneously, the trace will begin with the first view controller loading and end when that view controller calls `viewDidAppear`. 
 
@@ -45,20 +40,3 @@ struct MainView : View {
 ```
 
 The default suffix, ` - view appearing` will not be automatically applied when using the `reportName` API.
-
-
-## Tap instrumentation
-The tap instrumentation uses the UIApplicationDelegate's `sendEvent:` API to capture interactions with the UI. 
-
-Default instrumentation starts spans for all `touch` event types, but can be configured using `UIApplicationInstrumentationConfiguration.swift`.
-
-Spans will only be created at the `.ended` touch phase, and are terminated after half a second, or another tap occurs.
-
-Touch spans will be named using the following format: 
-
-`Tapped {view} in {viewController}`
-
-The name of the view will use the accessibilty label of the touch's view, or the nearest superview with an accessibility label, or the class name of the view, `type(of: view)`.
-The view controller name is captured similarly to the view controller instrumentation (described above), but the `reportName` api provided for SwiftUI will not work for tap instrumentation due to timing issues.
-
-Due to limitations of SwiftUI there is not yet a way to set a custom name for taps. 

--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -335,7 +335,7 @@ product:
 | --- | --- |
 | `Bool` | `true` |
 
-Previously turned [MetricKit](https://developer.apple.com/documentation/metrickit) instrumentation on or off. This option is deprecated and has no effect.
+Previously turned [MetricKit](https://developer.apple.com/documentation/metrickit) instrumentation on or off. This option is deprecated and has no effect because MetricKit instrumentation is incompatible with OpenTelemetry-Swift 2.x metrics.
 
 #### `withSystemMetrics(_:)` [withSystemMetrics]
 


### PR DESCRIPTION
## Summary

Correct the iOS SDK instrumentation documentation so it reflects supported behavior and explains why the deprecated MetricKit configuration has no effect.

## Changes

- Remove unsupported tap and user-action instrumentation claims while retaining the view-controller guidance.
- Document the OpenTelemetry-Swift 2.x metrics incompatibility behind the deprecated MetricKit option.