### PR TITLE
fix: isolate persisted telemetry by signal

### DIFF
--- a/Sources/Tests/apm-agent-iosTests/OpenTelemetryInitializerTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/OpenTelemetryInitializerTests.swift
@@ -1,0 +1,93 @@
+// Copyright © 2026 Elasticsearch BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+import Foundation
+import XCTest
+
+@testable import ElasticApm
+
+final class OpenTelemetryInitializerTests: XCTestCase {
+  private var temporaryDirectory: URL!
+
+  override func setUpWithError() throws {
+    temporaryDirectory = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: temporaryDirectory, withIntermediateDirectories: true)
+  }
+
+  override func tearDownWithError() throws {
+    try FileManager.default.removeItem(at: temporaryDirectory)
+  }
+
+  func testCreatesSeparateDirectoryForEachSignal() throws {
+    let paths = try OpenTelemetryInitializer.PersistenceSignal.allCases.map { signal in
+      try XCTUnwrap(
+        OpenTelemetryInitializer.createPersistenceFolder(
+          for: signal, baseDirectory: temporaryDirectory))
+    }
+
+    XCTAssertEqual(Set(paths).count, 3)
+    XCTAssertEqual(
+      Set(paths.map(\.lastPathComponent)),
+      Set(["logs", "traces", "metrics"]))
+
+    for path in paths {
+      var isDirectory: ObjCBool = false
+      XCTAssertTrue(
+        FileManager.default.fileExists(
+          atPath: path.path, isDirectory: &isDirectory))
+      XCTAssertTrue(isDirectory.boolValue)
+    }
+  }
+
+  func testRemovesLegacyFilesAndPreservesNestedDirectories() throws {
+    let legacyFile = temporaryDirectory.appendingPathComponent("807190670176")
+    let nestedDirectory = temporaryDirectory.appendingPathComponent(
+      "existing-signal", isDirectory: true)
+    let nestedFile = nestedDirectory.appendingPathComponent("batch")
+    try Data("legacy".utf8).write(to: legacyFile)
+    try FileManager.default.createDirectory(
+      at: nestedDirectory, withIntermediateDirectories: true)
+    try Data("nested".utf8).write(to: nestedFile)
+
+    XCTAssertNotNil(
+      OpenTelemetryInitializer.createPersistenceFolder(
+        for: .logs, baseDirectory: temporaryDirectory))
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: legacyFile.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: nestedFile.path))
+  }
+
+  func testCleanupFailureDoesNotDisableIsolatedStorage() throws {
+    let logsDirectory = temporaryDirectory.appendingPathComponent(
+      "logs", isDirectory: true)
+    let legacyFile = temporaryDirectory.appendingPathComponent("807190670176")
+    try FileManager.default.createDirectory(
+      at: logsDirectory, withIntermediateDirectories: true)
+    try Data("legacy".utf8).write(to: legacyFile)
+    try FileManager.default.setAttributes(
+      [.posixPermissions: 0o500], ofItemAtPath: temporaryDirectory.path)
+    defer {
+      try? FileManager.default.setAttributes(
+        [.posixPermissions: 0o700], ofItemAtPath: temporaryDirectory.path)
+    }
+
+    let result = OpenTelemetryInitializer.createPersistenceFolder(
+      for: .logs, baseDirectory: temporaryDirectory)
+
+    XCTAssertEqual(result, logsDirectory)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: legacyFile.path))
+  }
+}

--- a/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
+++ b/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
@@ -28,22 +28,89 @@ import os
 class OpenTelemetryInitializer {
   static let logLabel = "Elastic-OTLP-Exporter"
 
+  enum PersistenceSignal: String, CaseIterable {
+    case logs
+    case traces
+    case metrics
+  }
+
   let group: EventLoopGroup
   let sessionSampler: SessionSampler
 
-  static func createPersistenceFolder() -> URL? {
+  static func createPersistenceFolder(
+    for signal: PersistenceSignal,
+    fileManager: FileManager = .default,
+    baseDirectory: URL? = nil
+  ) -> URL? {
     do {
-      let cachesDir = try FileManager.default.url(
-        for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
-      let persistentDir = cachesDir.appendingPathComponent("elastic")
-      try FileManager.default.createDirectory(at: persistentDir, withIntermediateDirectories: true)
-      return persistentDir
+      let persistentDirectory: URL
+      if let baseDirectory {
+        persistentDirectory = baseDirectory
+      } else {
+        let cachesDirectory = try fileManager.url(
+          for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+        persistentDirectory = cachesDirectory.appendingPathComponent("elastic")
+      }
+
+      try fileManager.createDirectory(
+        at: persistentDirectory, withIntermediateDirectories: true)
+      // Direct files were written by the shared persistence layout from #371.
+      removeLegacyPersistenceFiles(
+        from: persistentDirectory, fileManager: fileManager)
+
+      let signalDirectory = persistentDirectory.appendingPathComponent(
+        signal.rawValue, isDirectory: true)
+      try fileManager.createDirectory(
+        at: signalDirectory, withIntermediateDirectories: true)
+      return signalDirectory
     } catch {
+      os_log(
+        "Unable to create the %{public}@ persistence directory: %{public}@",
+        type: .error,
+        signal.rawValue,
+        error.localizedDescription
+      )
       return nil
     }
   }
 
+  private static func removeLegacyPersistenceFiles(
+    from directory: URL,
+    fileManager: FileManager
+  ) {
+    let contents: [URL]
+    do {
+      contents = try fileManager.contentsOfDirectory(
+        at: directory,
+        includingPropertiesForKeys: [.isRegularFileKey],
+        options: [.skipsHiddenFiles]
+      )
+    } catch {
+      os_log(
+        "Unable to inspect the legacy persistence directory: %{public}@",
+        type: .error,
+        error.localizedDescription
+      )
+      return
+    }
 
+    for item in contents {
+      do {
+        let values = try item.resourceValues(forKeys: [.isRegularFileKey])
+        guard values.isRegularFile == true else {
+          continue
+        }
+        try fileManager.removeItem(at: item)
+      } catch {
+        os_log(
+          "Unable to remove legacy persistence file %{public}@: %{public}@",
+          type: .error,
+          item.lastPathComponent,
+          error.localizedDescription
+        )
+      }
+    }
+  }
 
   init(group: EventLoopGroup, sessionSampler: SessionSampler) {
     self.group = group
@@ -86,7 +153,7 @@ class OpenTelemetryInitializer {
       let defaultExporter = OtlpMetricExporter(
         channel: channel, config: otlpConfiguration, logger: Logger(label: Self.logLabel))
       do {
-        if let path = Self.createPersistenceFolder() {
+        if let path = Self.createPersistenceFolder(for: .metrics) {
           return try PersistenceMetricExporterDecorator(
             metricExporter: defaultExporter, storageURL: path, exportCondition: { true },
             performancePreset: configuration.instrumentation.storageConfiguration) as MetricExporter
@@ -99,7 +166,7 @@ class OpenTelemetryInitializer {
       let defaultExporter = OtlpTraceExporter(
         channel: channel, config: otlpConfiguration, logger: Logger(label: Self.logLabel))
       do {
-        if let path = Self.createPersistenceFolder() {
+        if let path = Self.createPersistenceFolder(for: .traces) {
           return try PersistenceSpanExporterDecorator(
             spanExporter: OtlpTraceExporter(
               channel: channel, config: otlpConfiguration, logger: Logger(label: Self.logLabel)),
@@ -114,7 +181,7 @@ class OpenTelemetryInitializer {
       let defaultExporter = OtlpLogExporter(
         channel: channel, config: otlpConfiguration, logger: Logger(label: Self.logLabel))
       do {
-        if let path = Self.createPersistenceFolder() {
+        if let path = Self.createPersistenceFolder(for: .logs) {
           return try PersistenceLogExporterDecorator(
             logRecordExporter: OtlpLogExporter(
               channel: channel, config: otlpConfiguration, logger: Logger(label: Self.logLabel)),
@@ -198,7 +265,7 @@ class OpenTelemetryInitializer {
       let metricEndpoint = URL(string: endpoint.absoluteString + "/v1/metrics")
       let defaultExporter = OtlpHttpMetricExporter(endpoint: metricEndpoint ?? endpoint, config: otlpConfiguration)
       do {
-        if let path = Self.createPersistenceFolder() {
+        if let path = Self.createPersistenceFolder(for: .metrics) {
           return try PersistenceMetricExporterDecorator(
             metricExporter: defaultExporter, storageURL: path, exportCondition: { true },
             performancePreset: configuration.instrumentation.storageConfiguration) as MetricExporter
@@ -211,7 +278,7 @@ class OpenTelemetryInitializer {
       let traceEndpoint = URL(string: endpoint.absoluteString + "/v1/traces")
       let defaultExporter = OtlpHttpTraceExporter(endpoint: traceEndpoint ?? endpoint, config:otlpConfiguration)
       do {
-        if let path = Self.createPersistenceFolder() {
+        if let path = Self.createPersistenceFolder(for: .traces) {
           return try PersistenceSpanExporterDecorator(
             spanExporter: defaultExporter,
             storageURL: path, exportCondition: { true },
@@ -225,7 +292,7 @@ class OpenTelemetryInitializer {
       let logsEndpoint = URL(string: endpoint.absoluteString + "/v1/logs")
       let defaultExporter = OtlpHttpLogExporter(endpoint: logsEndpoint ?? endpoint, config: otlpConfiguration)
       do {
-        if let path = Self.createPersistenceFolder() {
+        if let path = Self.createPersistenceFolder(for: .logs) {
           return try PersistenceLogExporterDecorator(
             logRecordExporter: defaultExporter,
             storageURL: path, exportCondition: { true },

--- a/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
+++ b/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
@@ -54,7 +54,6 @@ class OpenTelemetryInitializer {
 
       try fileManager.createDirectory(
         at: persistentDirectory, withIntermediateDirectories: true)
-      // Direct files were written by the shared persistence layout from #371.
       removeLegacyPersistenceFiles(
         from: persistentDirectory, fileManager: fileManager)
 


### PR DESCRIPTION
## Summary

Prevent persisted logs, traces, and metrics from consuming each other's storage. `swift test` passes. Closes #371.

## Changes

- Store each signal in its own persistence directory for OTLP/HTTP and OTLP/gRPC.
- Remove legacy batch files from the former shared directory while preserving nested directories and reporting cleanup failures.
- Add focused tests for signal isolation, legacy cleanup, and cleanup failure behavior.