### PR TITLE
Improve iOS attributes test confidence

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,9 +74,19 @@ let package = Package(
         .process("Resources/PrivacyInfo.xcprivacy")
       ]
     ),
+    .target(
+      name: "ElasticApmTestSupport",
+      dependencies: [
+        .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core")
+      ],
+      path: "Sources/Tests/ElasticApmTestSupport"),
     .testTarget(
       name: "ElasticApmTests",
-      dependencies: ["ElasticApm"],
+      dependencies: [
+        "ElasticApm",
+        "ElasticApmTestSupport",
+        .product(name: "ResourceExtension", package: "opentelemetry-swift")
+      ],
       path: "Sources/Tests/apm-agent-iosTests"),
     .testTarget(
       name: "MemorySamplerTests",

--- a/Package.swift
+++ b/Package.swift
@@ -85,12 +85,27 @@ let package = Package(
       dependencies: [
         "ElasticApm",
         "ElasticApmTestSupport",
-        .product(name: "ResourceExtension", package: "opentelemetry-swift")
+        .product(name: "ResourceExtension", package: "opentelemetry-swift"),
+        .product(name: "URLSessionInstrumentation", package: "opentelemetry-swift")
       ],
       path: "Sources/Tests/apm-agent-iosTests"),
     .testTarget(
       name: "MemorySamplerTests",
-      dependencies: ["MemorySampler"],
+      dependencies: [
+        "MemorySampler",
+        "ElasticApmTestSupport",
+        .product(name: "OpenTelemetryApi", package: "opentelemetry-swift-core"),
+        .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core")
+      ],
       path: "Sources/Tests/memory-sampler-tests"),
+    .testTarget(
+      name: "CPUSamplerTests",
+      dependencies: [
+        "CPUSampler",
+        "ElasticApmTestSupport",
+        .product(name: "OpenTelemetryApi", package: "opentelemetry-swift-core"),
+        .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift-core")
+      ],
+      path: "Sources/Tests/cpu-sampler-tests")
   ]
 )

--- a/Sources/Instrumentation/CPUSampler/CPUSampler.swift
+++ b/Sources/Instrumentation/CPUSampler/CPUSampler.swift
@@ -61,14 +61,23 @@ public class CPUSampler {
   ) -> ObservableDoubleGauge {
     let metricName =
       useLegacyAttributeNames ? "system.cpu.usage" : "process.cpu.utilization"
-    return meter.gaugeBuilder(name: metricName).buildWithCallback({ measurement in
+    let unit = useLegacyAttributeNames ? "" : "1"
+    let builder = meter.gaugeBuilder(name: metricName)
+    _ = (builder as? DoubleGaugeBuilderSdk)?.setUnit(unit)
+    return builder.buildWithCallback({ measurement in
       let percentSum = cpuFootprint()
       let value =
         useLegacyAttributeNames
         ? percentSum
         : Self.utilization(fromPercentSum: percentSum)
       let attributes: [String: AttributeValue] =
-        useLegacyAttributeNames ? ["state": .string("app")] : [:]
+        useLegacyAttributeNames
+        ? ["state": .string("app")]
+        : [
+          // Darwin reports aggregate process CPU usage rather than separate user/system values.
+          SemanticConventions.Cpu.mode.rawValue:
+            .string(SemanticConventions.Cpu.ModeValues("total").description)
+        ]
       measurement.record(value: value, attributes: attributes)
     })
   }

--- a/Sources/Instrumentation/CPUSampler/CPUSampler.swift
+++ b/Sources/Instrumentation/CPUSampler/CPUSampler.swift
@@ -19,19 +19,73 @@ import OpenTelemetrySdk
 public class CPUSampler {
   let meter: any Meter
   var gauge: ObservableDoubleGauge
+
     public init() {
-      meter = OpenTelemetry.instance.meterProvider
-        .meterBuilder(name: "CPU Sampler")
-        .setInstrumentationVersion(instrumentationVersion: "1.0.0")
-        .build()
-      gauge = meter.gaugeBuilder(name: "system.cpu.usage").buildWithCallback({ measurement in
-        measurement.record(value: CPUSampler.cpuFootprint(), attributes: ["state": .string("app")])
-      })
+      let meter = Self.makeMeter()
+      self.meter = meter
+      gauge = Self.makeGauge(
+        meter: meter,
+        useLegacyAttributeNames: false,
+        cpuFootprint: Self.cpuFootprint)
     }
+
+  public convenience init(useLegacyAttributeNames: Bool) {
+    self.init(
+      useLegacyAttributeNames: useLegacyAttributeNames,
+      cpuFootprint: Self.cpuFootprint)
+  }
+
+  init(
+    useLegacyAttributeNames: Bool,
+    cpuFootprint: @escaping () -> Double
+  ) {
+    let meter = Self.makeMeter()
+    self.meter = meter
+    gauge = Self.makeGauge(
+      meter: meter,
+      useLegacyAttributeNames: useLegacyAttributeNames,
+      cpuFootprint: cpuFootprint)
+  }
+
+  private static func makeMeter() -> any Meter {
+    OpenTelemetry.instance.meterProvider
+      .meterBuilder(name: "CPU Sampler")
+      .setInstrumentationVersion(instrumentationVersion: "1.0.0")
+      .build()
+  }
+
+  private static func makeGauge(
+    meter: any Meter,
+    useLegacyAttributeNames: Bool,
+    cpuFootprint: @escaping () -> Double
+  ) -> ObservableDoubleGauge {
+    let metricName =
+      useLegacyAttributeNames ? "system.cpu.usage" : "process.cpu.utilization"
+    return meter.gaugeBuilder(name: metricName).buildWithCallback({ measurement in
+      let percentSum = cpuFootprint()
+      let value =
+        useLegacyAttributeNames
+        ? percentSum
+        : Self.utilization(fromPercentSum: percentSum)
+      let attributes: [String: AttributeValue] =
+        useLegacyAttributeNames ? ["state": .string("app")] : [:]
+      measurement.record(value: value, attributes: attributes)
+    })
+  }
 
   deinit {
     gauge.close()
   }
+
+    static func utilization(
+      fromPercentSum percentSum: Double,
+      processorCount: Int = ProcessInfo.processInfo.activeProcessorCount
+    ) -> Double {
+      guard processorCount > 0 else {
+        return 0
+      }
+      return min(max(percentSum / 100.0 / Double(processorCount), 0), 1)
+    }
 
     static func cpuFootprint() -> Double {
         var kr: kern_return_t

--- a/Sources/Instrumentation/MemorySampler/MemorySampler.swift
+++ b/Sources/Instrumentation/MemorySampler/MemorySampler.swift
@@ -18,22 +18,59 @@ import OpenTelemetrySdk
 
 public class MemorySampler {
   let meter: any Meter
-  var gauge: ObservableLongGauge
+  var gauge: ObservableDoubleGauge
 
     public init() {
-      meter = OpenTelemetry.instance.meterProvider
-        .meterBuilder(name: "Memory Sampler")
-        .setInstrumentationVersion(instrumentationVersion: "1.0.0")
-        .build()
-      gauge = meter
-        .gaugeBuilder(name: "system.memory.usage")
-        .ofLongs()
-        .buildWithCallback({ gauge in
-            if let memoryUsage = MemorySampler.memoryFootprint() {
-              gauge.record(value: Int(memoryUsage), attributes: ["state": .string("app")])
-            }
-        })
+      let meter = Self.makeMeter()
+      self.meter = meter
+      gauge = Self.makeGauge(
+        meter: meter,
+        useLegacyAttributeNames: false,
+        memoryFootprint: Self.memoryFootprint)
     }
+
+  public convenience init(useLegacyAttributeNames: Bool) {
+    self.init(
+      useLegacyAttributeNames: useLegacyAttributeNames,
+      memoryFootprint: Self.memoryFootprint)
+  }
+
+  init(
+    useLegacyAttributeNames: Bool,
+    memoryFootprint: @escaping () -> mach_vm_size_t?
+  ) {
+    let meter = Self.makeMeter()
+    self.meter = meter
+    gauge = Self.makeGauge(
+      meter: meter,
+      useLegacyAttributeNames: useLegacyAttributeNames,
+      memoryFootprint: memoryFootprint)
+  }
+
+  private static func makeMeter() -> any Meter {
+    OpenTelemetry.instance.meterProvider
+      .meterBuilder(name: "Memory Sampler")
+      .setInstrumentationVersion(instrumentationVersion: "1.0.0")
+      .build()
+  }
+
+  private static func makeGauge(
+    meter: any Meter,
+    useLegacyAttributeNames: Bool,
+    memoryFootprint: @escaping () -> mach_vm_size_t?
+  ) -> ObservableDoubleGauge {
+    let metricName =
+      useLegacyAttributeNames ? "system.memory.usage" : "process.memory.usage"
+    return meter
+      .gaugeBuilder(name: metricName)
+      .buildWithCallback({ gauge in
+        if let memoryUsage = memoryFootprint() {
+          let attributes: [String: AttributeValue] =
+            useLegacyAttributeNames ? ["state": .string("app")] : [:]
+          gauge.record(value: Double(memoryUsage), attributes: attributes)
+        }
+      })
+  }
 
   deinit {
     gauge.close()

--- a/Sources/Instrumentation/MemorySampler/MemorySampler.swift
+++ b/Sources/Instrumentation/MemorySampler/MemorySampler.swift
@@ -18,12 +18,12 @@ import OpenTelemetrySdk
 
 public class MemorySampler {
   let meter: any Meter
-  var gauge: ObservableDoubleGauge
+  let closeInstrument: () -> Void
 
     public init() {
       let meter = Self.makeMeter()
       self.meter = meter
-      gauge = Self.makeGauge(
+      closeInstrument = Self.makeInstrument(
         meter: meter,
         useLegacyAttributeNames: false,
         memoryFootprint: Self.memoryFootprint)
@@ -41,7 +41,7 @@ public class MemorySampler {
   ) {
     let meter = Self.makeMeter()
     self.meter = meter
-    gauge = Self.makeGauge(
+    closeInstrument = Self.makeInstrument(
       meter: meter,
       useLegacyAttributeNames: useLegacyAttributeNames,
       memoryFootprint: memoryFootprint)
@@ -54,26 +54,40 @@ public class MemorySampler {
       .build()
   }
 
-  private static func makeGauge(
+  private static func makeInstrument(
     meter: any Meter,
     useLegacyAttributeNames: Bool,
     memoryFootprint: @escaping () -> mach_vm_size_t?
-  ) -> ObservableDoubleGauge {
+  ) -> () -> Void {
     let metricName =
       useLegacyAttributeNames ? "system.memory.usage" : "process.memory.usage"
-    return meter
-      .gaugeBuilder(name: metricName)
-      .buildWithCallback({ gauge in
-        if let memoryUsage = memoryFootprint() {
-          let attributes: [String: AttributeValue] =
-            useLegacyAttributeNames ? ["state": .string("app")] : [:]
-          gauge.record(value: Double(memoryUsage), attributes: attributes)
-        }
-      })
+    let callback: (ObservableDoubleMeasurement) -> Void = { measurement in
+      if let memoryUsage = memoryFootprint() {
+        let attributes: [String: AttributeValue] =
+          useLegacyAttributeNames ? ["state": .string("app")] : [:]
+        measurement.record(value: Double(memoryUsage), attributes: attributes)
+      }
+    }
+
+    if useLegacyAttributeNames {
+      let gauge = meter
+        .gaugeBuilder(name: metricName)
+        .buildWithCallback(callback)
+      return { gauge.close() }
+    }
+
+    let builder = meter
+      .upDownCounterBuilder(name: metricName)
+      .ofDoubles()
+    _ = (builder as? DoubleUpDownCounterBuilderSdk)?.setUnit("By")
+    let upDownCounter = builder.buildWithCallback { measurement in
+      callback(measurement)
+    }
+    return { upDownCounter.close() }
   }
 
   deinit {
-    gauge.close()
+    closeInstrument()
   }
 
     static func memoryFootprint() -> mach_vm_size_t? {

--- a/Sources/Tests/ElasticApmTestSupport/WaitingExporters.swift
+++ b/Sources/Tests/ElasticApmTestSupport/WaitingExporters.swift
@@ -1,0 +1,155 @@
+// Copyright © 2026 Elasticsearch BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+import Foundation
+import OpenTelemetrySdk
+
+public final class WaitingSpanExporter: SpanExporter, @unchecked Sendable {
+  private var spanDataList = [SpanData]()
+  private let condition = NSCondition()
+  private let numberToWaitFor: Int
+  public private(set) var shutdownCalled = false
+
+  public init(numberToWaitFor: Int) {
+    self.numberToWaitFor = numberToWaitFor
+  }
+
+  public func waitForExport(timeout: TimeInterval = 10) -> [SpanData]? {
+    condition.lock()
+    defer { condition.unlock() }
+
+    let deadline = Date().addingTimeInterval(timeout)
+    while spanDataList.count < numberToWaitFor {
+      guard condition.wait(until: deadline) else {
+        return nil
+      }
+    }
+    let exported = spanDataList
+    spanDataList.removeAll()
+    return exported
+  }
+
+  public func export(
+    spans: [SpanData],
+    explicitTimeout: TimeInterval? = nil
+  ) -> SpanExporterResultCode {
+    condition.lock()
+    spanDataList.append(contentsOf: spans)
+    condition.broadcast()
+    condition.unlock()
+    return .success
+  }
+
+  public func flush(explicitTimeout: TimeInterval? = nil) -> SpanExporterResultCode {
+    .success
+  }
+
+  public func shutdown(explicitTimeout: TimeInterval? = nil) {
+    shutdownCalled = true
+  }
+}
+
+public final class WaitingLogRecordExporter: LogRecordExporter, @unchecked Sendable {
+  private var logRecordList = [ReadableLogRecord]()
+  private let condition = NSCondition()
+  private let numberToWaitFor: Int
+  public private(set) var shutdownCalled = false
+
+  public init(numberToWaitFor: Int) {
+    self.numberToWaitFor = numberToWaitFor
+  }
+
+  public func waitForExport(timeout: TimeInterval = 10) -> [ReadableLogRecord]? {
+    condition.lock()
+    defer { condition.unlock() }
+
+    let deadline = Date().addingTimeInterval(timeout)
+    while logRecordList.count < numberToWaitFor {
+      guard condition.wait(until: deadline) else {
+        return nil
+      }
+    }
+    let exported = logRecordList
+    logRecordList.removeAll()
+    return exported
+  }
+
+  public func export(
+    logRecords: [ReadableLogRecord],
+    explicitTimeout: TimeInterval? = nil
+  ) -> ExportResult {
+    condition.lock()
+    logRecordList.append(contentsOf: logRecords)
+    condition.broadcast()
+    condition.unlock()
+    return .success
+  }
+
+  public func forceFlush(explicitTimeout: TimeInterval? = nil) -> ExportResult {
+    .success
+  }
+
+  public func shutdown(explicitTimeout: TimeInterval? = nil) {
+    shutdownCalled = true
+  }
+}
+
+public final class WaitingMetricExporter: MetricExporter {
+  private var metricDataList = [MetricData]()
+  private let condition = NSCondition()
+  private let numberToWaitFor: Int
+  public private(set) var shutdownCalled = false
+
+  public init(numberToWaitFor: Int) {
+    self.numberToWaitFor = numberToWaitFor
+  }
+
+  public func waitForExport(timeout: TimeInterval = 10) -> [MetricData]? {
+    condition.lock()
+    defer { condition.unlock() }
+
+    let deadline = Date().addingTimeInterval(timeout)
+    while metricDataList.count < numberToWaitFor {
+      guard condition.wait(until: deadline) else {
+        return nil
+      }
+    }
+    let exported = metricDataList
+    metricDataList.removeAll()
+    return exported
+  }
+
+  public func export(metrics: [MetricData]) -> ExportResult {
+    condition.lock()
+    metricDataList.append(contentsOf: metrics)
+    condition.broadcast()
+    condition.unlock()
+    return .success
+  }
+
+  public func flush() -> ExportResult {
+    .success
+  }
+
+  public func shutdown() -> ExportResult {
+    shutdownCalled = true
+    return .success
+  }
+
+  public func getAggregationTemporality(
+    for instrument: InstrumentType
+  ) -> AggregationTemporality {
+    .cumulative
+  }
+}

--- a/Sources/Tests/apm-agent-iosTests/AgentConfigurationTest.swift
+++ b/Sources/Tests/apm-agent-iosTests/AgentConfigurationTest.swift
@@ -92,6 +92,23 @@ final class AgentConfigurationTest: XCTestCase {
     )
   }
 
+  func testLegacyAttributeNamesAreDisabledByDefaultAndCanBeSelectedExplicitly() {
+    XCTAssertFalse(AgentConfigBuilder().build().useLegacyAttributeNames)
+    XCTAssertTrue(
+      AgentConfigBuilder()
+        .useLegacyAttributeNames(true)
+        .build()
+        .useLegacyAttributeNames
+    )
+    XCTAssertFalse(
+      AgentConfigBuilder()
+        .useLegacyAttributeNames(true)
+        .useLegacyAttributeNames(false)
+        .build()
+        .useLegacyAttributeNames
+    )
+  }
+
   func testDeprecatedServerURLRemainsCompatibleAndExportURLTakesPrecedence() {
     let serverUrl = URL(string: "http://legacy.example.com:4317")!
     let exportUrl = URL(string: "https://export.example.com:4318/v1")!

--- a/Sources/Tests/apm-agent-iosTests/ApplicationLifecycleInstrumentationTest.swift
+++ b/Sources/Tests/apm-agent-iosTests/ApplicationLifecycleInstrumentationTest.swift
@@ -12,125 +12,91 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-import Foundation
-import OpenTelemetryApi
-import OpenTelemetrySdk
-import ElasticApmTestSupport
-@testable import ElasticApm
-import XCTest
+#if canImport(UIKit) && !os(watchOS) // UIApplication lifecycle events are unavailable on macOS and watchOS.
+  import ElasticApmTestSupport
+  import Foundation
+  import OpenTelemetryApi
+  import OpenTelemetrySdk
+  @testable import ElasticApm
+  import XCTest
 
-#if canImport(UIKit) && !os(watchOS)
-class ApplicationLifecycleInstrumentationTest: XCTestCase {
-    func testLifecycleActive() {
-        let waitingExporter = WaitingLogRecordExporter(numberToWaitFor: 1)
-
-        let config = AgentConfiguration()
-
-      let  factory = LoggerProviderSdk(
-        logRecordProcessors: [ElasticLogRecordProcessor(logRecordExporter: waitingExporter, configuration: config, scheduleDelay: 0.5)]
-      )
-
-        OpenTelemetry.registerLoggerProvider(loggerProvider: factory)
-
-        let appLifecycleInstrumentation = ApplicationLifecycleInstrumentation()
-        appLifecycleInstrumentation.active(Notification(name: Notification.Name("test")))
-
-        let exported = waitingExporter.waitForExport()
-
-        XCTAssertEqual(exported?.count, 1)
-        XCTAssertNotNil(exported?[0].attributes["lifecycle.state"])
-        XCTAssertEqual(exported?[0].eventName, "lifecycle")
-        XCTAssertEqual(exported?[0].attributes["lifecycle.state"]?.description, "active")
+  final class ApplicationLifecycleInstrumentationTest: XCTestCase {
+    func testDefaultLifecycleEventsUseSemanticConventionNames() throws {
+      try assertLifecycleEvents(useLegacyAttributeNames: false)
     }
 
-    func testLifecycleInactive() {
-        let waitingExporter = WaitingLogRecordExporter(numberToWaitFor: 1)
-
-      let config = AgentConfiguration()
-
-
-      let  factory = LoggerProviderSdk(
-        logRecordProcessors: [ElasticLogRecordProcessor(logRecordExporter: waitingExporter, configuration: config, scheduleDelay: 0.5)]
-      )
-
-        OpenTelemetry.registerLoggerProvider(loggerProvider: factory)
-
-        let appLifecycleInstrumentation = ApplicationLifecycleInstrumentation()
-        appLifecycleInstrumentation.inactive(Notification(name: Notification.Name("test")))
-
-        let exported = waitingExporter.waitForExport()
-
-        XCTAssertEqual(exported?.count, 1)
-        XCTAssertNotNil(exported?[0].attributes["lifecycle.state"])
-        XCTAssertEqual(exported?[0].eventName, "lifecycle")
-        XCTAssertEqual(exported?[0].attributes["lifecycle.state"]?.description, "inactive")
+    func testLegacyLifecycleEventsRestorePreviousNames() throws {
+      try assertLifecycleEvents(useLegacyAttributeNames: true)
     }
 
-    func testLifecycleBackground() {
-        let waitingExporter = WaitingLogRecordExporter(numberToWaitFor: 1)
+    private func assertLifecycleEvents(useLegacyAttributeNames: Bool) throws {
+      let cases: [
+        (
+          state: SemanticConventions.Ios.AppStateValues,
+          emit: (ApplicationLifecycleInstrumentation) -> Void
+        )
+      ] = [
+        (.active, { $0.active(Notification(name: Notification.Name("test"))) }),
+        (.inactive, { $0.inactive(Notification(name: Notification.Name("test"))) }),
+        (.background, { $0.background(Notification(name: Notification.Name("test"))) }),
+        (.foreground, { $0.foreground(Notification(name: Notification.Name("test"))) }),
+        (.terminate, { $0.terminate(Notification(name: Notification.Name("test"))) })
+      ]
 
-      let config = AgentConfiguration()
+      let centralConfig = CentralConfig()
+      let previousCentralConfig = centralConfig.config
+      centralConfig.config = nil
+      defer {
+        centralConfig.config = previousCentralConfig
+      }
 
-      let  factory = LoggerProviderSdk(
-        logRecordProcessors: [ElasticLogRecordProcessor(logRecordExporter: waitingExporter,configuration: config, scheduleDelay: 0.5)]
-      )
+      for lifecycleCase in cases {
+        let exported = try exportLifecycleEvent(
+          useLegacyAttributeNames: useLegacyAttributeNames,
+          emit: lifecycleCase.emit
+        )
+        let expectedEventName =
+          useLegacyAttributeNames ? "lifecycle" : "device.app.lifecycle"
+        let expectedAttributeName =
+          useLegacyAttributeNames ? "lifecycle.state" : "ios.app.state"
+        let rejectedEventName =
+          useLegacyAttributeNames ? "device.app.lifecycle" : "lifecycle"
+        let rejectedAttributeName =
+          useLegacyAttributeNames ? "ios.app.state" : "lifecycle.state"
 
-        OpenTelemetry.registerLoggerProvider(loggerProvider: factory)
-
-        let appLifecycleInstrumentation = ApplicationLifecycleInstrumentation()
-        appLifecycleInstrumentation.background(Notification(name: Notification.Name("test")))
-
-        let exported = waitingExporter.waitForExport()
-
-        XCTAssertEqual(exported?.count, 1)
-        XCTAssertNotNil(exported?[0].attributes["lifecycle.state"])
-        XCTAssertEqual(exported?[0].eventName, "lifecycle")
-        XCTAssertEqual(exported?[0].attributes["lifecycle.state"]?.description, "background")
+        XCTAssertEqual(exported.eventName, expectedEventName)
+        XCTAssertNotEqual(exported.eventName, rejectedEventName)
+        XCTAssertEqual(
+          exported.attributes[expectedAttributeName],
+          .string(lifecycleCase.state.description)
+        )
+        XCTAssertNil(exported.attributes[rejectedAttributeName])
+      }
     }
-    func testLifecycleForeground() {
-        let waitingExporter = WaitingLogRecordExporter(numberToWaitFor: 1)
 
-      let config = AgentConfiguration()
-
-      let  factory = LoggerProviderSdk(
-        logRecordProcessors: [ElasticLogRecordProcessor(logRecordExporter: waitingExporter,configuration: config, scheduleDelay: 0.5)]
+    private func exportLifecycleEvent(
+      useLegacyAttributeNames: Bool,
+      emit: (ApplicationLifecycleInstrumentation) -> Void
+    ) throws -> ReadableLogRecord {
+      let exporter = WaitingLogRecordExporter(numberToWaitFor: 1)
+      let provider = LoggerProviderSdk(
+        logRecordProcessors: [
+          ElasticLogRecordProcessor(
+            logRecordExporter: exporter,
+            configuration: AgentConfigBuilder()
+              .useLegacyAttributeNames(useLegacyAttributeNames)
+              .build(),
+            scheduleDelay: 0.01
+          )
+        ]
       )
+      OpenTelemetry.registerLoggerProvider(loggerProvider: provider)
 
-        OpenTelemetry.registerLoggerProvider(loggerProvider: factory)
+      let instrumentation = ApplicationLifecycleInstrumentation(
+        useLegacyAttributeNames: useLegacyAttributeNames)
+      emit(instrumentation)
 
-        let appLifecycleInstrumentation = ApplicationLifecycleInstrumentation()
-        appLifecycleInstrumentation.foreground(Notification(name: Notification.Name("test")))
-
-        let exported = waitingExporter.waitForExport()
-
-        XCTAssertEqual(exported?.count, 1)
-        XCTAssertNotNil(exported?[0].attributes["lifecycle.state"])
-        XCTAssertEqual(exported?[0].eventName, "lifecycle")
-        XCTAssertEqual(exported?[0].attributes["lifecycle.state"]?.description, "foreground")
+      return try XCTUnwrap(exporter.waitForExport()?.first)
     }
-
-    func testLifecycleTerminate() {
-        let waitingExporter = WaitingLogRecordExporter(numberToWaitFor: 1)
-
-      let config = AgentConfiguration()
-
-      let  factory = LoggerProviderSdk(
-        logRecordProcessors: [ElasticLogRecordProcessor(logRecordExporter: waitingExporter, configuration: config, scheduleDelay: 0.5)]
-      )
-
-        OpenTelemetry.registerLoggerProvider(loggerProvider: factory)
-
-        let appLifecycleInstrumentation = ApplicationLifecycleInstrumentation()
-        appLifecycleInstrumentation.terminate(Notification(name: Notification.Name("test")))
-
-        let exported = waitingExporter.waitForExport()
-
-        XCTAssertEqual(exported?.count, 1)
-        XCTAssertNotNil(exported?[0].attributes["lifecycle.state"])
-        XCTAssertEqual(exported?[0].eventName, "lifecycle")
-        XCTAssertEqual(exported?[0].attributes["lifecycle.state"]?.description, "terminate")
-    }
-}
-#else
-class ApplicationLifecycleInstrumentationTest: XCTestCase {}
+  }
 #endif

--- a/Sources/Tests/apm-agent-iosTests/ApplicationLifecycleInstrumentationTest.swift
+++ b/Sources/Tests/apm-agent-iosTests/ApplicationLifecycleInstrumentationTest.swift
@@ -15,6 +15,7 @@
 import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
+import ElasticApmTestSupport
 @testable import ElasticApm
 import XCTest
 

--- a/Sources/Tests/apm-agent-iosTests/CrashManagerTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/CrashManagerTests.swift
@@ -1,0 +1,43 @@
+// Copyright © 2026 Elasticsearch BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+#if !os(watchOS) // Crash reporting is not supported on watchOS.
+  import XCTest
+
+  @testable import ElasticApm
+
+  final class CrashManagerTests: XCTestCase {
+    func testDefaultCrashEventUsesCurrentName() {
+      XCTAssertEqual(
+        CrashManager.eventName(useLegacyAttributeNames: false),
+        "app.crash"
+      )
+      XCTAssertNotEqual(
+        CrashManager.eventName(useLegacyAttributeNames: false),
+        "crash"
+      )
+    }
+
+    func testLegacyCrashEventRestoresPreviousName() {
+      XCTAssertEqual(
+        CrashManager.eventName(useLegacyAttributeNames: true),
+        "crash"
+      )
+      XCTAssertNotEqual(
+        CrashManager.eventName(useLegacyAttributeNames: true),
+        "app.crash"
+      )
+    }
+  }
+#endif

--- a/Sources/Tests/apm-agent-iosTests/ElasticLogRecordProcessorTest.swift
+++ b/Sources/Tests/apm-agent-iosTests/ElasticLogRecordProcessorTest.swift
@@ -14,6 +14,7 @@
 
 import OpenTelemetryApi
 import OpenTelemetrySdk
+import ElasticApmTestSupport
 @testable import ElasticApm
 import XCTest
 
@@ -116,47 +117,4 @@ class ElasticLogRecordProcessorTest: XCTestCase {
 
   }
 
-}
-
-
-
-class WaitingLogRecordExporter: LogRecordExporter {
-    var logRecordList = [ReadableLogRecord]()
-    let cond = NSCondition()
-    let numberToWaitFor: Int
-    var shutdownCalled = false
-
-    init(numberToWaitFor: Int) {
-        self.numberToWaitFor = numberToWaitFor
-    }
-
-    func export(logRecords: [OpenTelemetrySdk.ReadableLogRecord], explicitTimeout: TimeInterval? = nil) -> OpenTelemetrySdk.ExportResult {
-        cond.lock()
-        logRecordList.append(contentsOf: logRecords)
-        cond.unlock()
-        cond.broadcast()
-        return .success
-    }
-
-    func waitForExport() -> [ReadableLogRecord]? {
-        var ret: [ReadableLogRecord]
-        cond.lock()
-        defer { cond.unlock() }
-
-        while logRecordList.count < numberToWaitFor {
-            cond.wait()
-        }
-        ret = logRecordList
-        logRecordList.removeAll()
-
-        return ret
-    }
-
-    func forceFlush(explicitTimeout: TimeInterval? = nil) -> ExportResult {
-        return .success
-    }
-
-    func shutdown(explicitTimeout: TimeInterval? = nil) {
-        shutdownCalled = true
-    }
 }

--- a/Sources/Tests/apm-agent-iosTests/ElasticSpanProcessorTest.swift
+++ b/Sources/Tests/apm-agent-iosTests/ElasticSpanProcessorTest.swift
@@ -14,6 +14,7 @@
 
 import OpenTelemetryApi
 import OpenTelemetrySdk
+import ElasticApmTestSupport
 @testable import ElasticApm
 import XCTest
 
@@ -157,46 +158,5 @@ class SessionSpanProcessorTest: XCTestCase {
     let exported = waitingSpanExporter.waitForExport()
 
     XCTAssertTrue(exported?[0].attributes["foo"]?.description == "bar")
-  }
-}
-
-class WaitingSpanExporter: SpanExporter {
-  var spanDataList = [SpanData]()
-  let cond = NSCondition()
-  let numberToWaitFor: Int
-  var shutdownCalled = false
-
-  init(numberToWaitFor: Int) {
-    self.numberToWaitFor = numberToWaitFor
-  }
-
-  func waitForExport() -> [SpanData]? {
-    var ret: [SpanData]
-    cond.lock()
-    defer { cond.unlock() }
-
-    while spanDataList.count < numberToWaitFor {
-      cond.wait()
-    }
-    ret = spanDataList
-    spanDataList.removeAll()
-
-    return ret
-  }
-
-  func export(spans: [SpanData], explicitTimeout: TimeInterval? = nil) -> SpanExporterResultCode {
-    cond.lock()
-    spanDataList.append(contentsOf: spans)
-    cond.unlock()
-    cond.broadcast()
-    return .success
-  }
-
-  func flush(explicitTimeout: TimeInterval? = nil) -> SpanExporterResultCode {
-    return .success
-  }
-
-  func shutdown(explicitTimeout: TimeInterval? = nil) {
-    shutdownCalled = true
   }
 }

--- a/Sources/Tests/apm-agent-iosTests/InstrumentationWrapperTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/InstrumentationWrapperTests.swift
@@ -1,0 +1,57 @@
+// Copyright © 2026 Elasticsearch BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+import OpenTelemetrySdk
+import URLSessionInstrumentation
+import XCTest
+
+@testable import ElasticApm
+
+final class InstrumentationWrapperTests: XCTestCase {
+  func testDefaultURLSessionConfigurationUsesStableHTTPConventions() {
+    let configuration = makeWrapper(useLegacyAttributeNames: false)
+      .makeURLSessionInstrumentationConfiguration()
+
+    guard case .stable = configuration.semanticConvention else {
+      return XCTFail("Default URLSession instrumentation must use stable HTTP conventions")
+    }
+  }
+
+  func testLegacyURLSessionConfigurationUsesOldHTTPConventions() {
+    let configuration = makeWrapper(useLegacyAttributeNames: true)
+      .makeURLSessionInstrumentationConfiguration()
+
+    guard case .old = configuration.semanticConvention else {
+      return XCTFail("Legacy URLSession instrumentation must use old HTTP conventions")
+    }
+  }
+
+  private func makeWrapper(useLegacyAttributeNames: Bool) -> InstrumentationWrapper {
+    let agentConfiguration = AgentConfigBuilder()
+      .withRemoteManagement(false)
+      .useLegacyAttributeNames(useLegacyAttributeNames)
+      .build()
+    let instrumentationConfiguration = InstrumentationConfigBuilder()
+      .withLifecycleEvents(false)
+      .withViewControllerInstrumentation(false)
+      .withSystemMetrics(false)
+      .build()
+    let manager = AgentConfigManager(
+      resource: Resource(),
+      config: agentConfiguration,
+      instrumentationConfig: instrumentationConfiguration
+    )
+    return InstrumentationWrapper(config: manager)
+  }
+}

--- a/Sources/Tests/apm-agent-iosTests/TelemetryAttributeSmokeTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/TelemetryAttributeSmokeTests.swift
@@ -24,8 +24,8 @@ import XCTest
 
 final class ResourceAttributeSmokeTests: XCTestCase {
   func testCompleteResourceOnSpansLogsAndMetrics() throws {
-    try withSmokeTelemetry { harness in
-      let expected = try expectedResourceAttributes()
+    try withSmokeTelemetry(useLegacyAttributeNames: false) { harness in
+      let expected = try expectedResourceAttributes(useLegacyAttributeNames: false)
       harness.emitSpanAndLog()
       let metric = try harness.emitMetric()
       let span = try harness.waitForSpan()
@@ -34,13 +34,46 @@ final class ResourceAttributeSmokeTests: XCTestCase {
       XCTAssertEqual(span.resource.attributes, expected)
       XCTAssertEqual(log.resource.attributes, expected)
       XCTAssertEqual(metric.resource.attributes, expected)
+      XCTAssertNil(span.resource.attributes["service.build"])
+      XCTAssertNotEqual(
+        span.resource.attributes["telemetry.sdk.version"],
+        .string("semver:\(ElasticApmAgent.elasticSwiftAgentVersion)")
+      )
+    }
+  }
+
+  func testCompleteLegacyResourceOnSpansLogsAndMetrics() throws {
+    try withSmokeTelemetry(useLegacyAttributeNames: true) { harness in
+      let expected = try expectedResourceAttributes(useLegacyAttributeNames: true)
+      harness.emitSpanAndLog()
+      let metric = try harness.emitMetric()
+      let span = try harness.waitForSpan()
+      let log = try harness.waitForLog()
+
+      XCTAssertEqual(span.resource.attributes, expected)
+      XCTAssertEqual(log.resource.attributes, expected)
+      XCTAssertEqual(metric.resource.attributes, expected)
+      XCTAssertEqual(
+        span.resource.attributes["telemetry.sdk.version"],
+        .string("semver:\(ElasticApmAgent.elasticSwiftAgentVersion)")
+      )
+      XCTAssertNotEqual(
+        span.resource.attributes["telemetry.sdk.version"],
+        .string(ElasticApmAgent.elasticSwiftAgentVersion)
+      )
+
+      let application = ApplicationDataSource()
+      if application.build != nil, application.version != nil {
+        XCTAssertNotNil(span.resource.attributes["service.build"])
+        XCTAssertNil(span.resource.attributes["app.build_id"])
+      }
     }
   }
 }
 
 final class GlobalSignalAttributeSmokeTests: XCTestCase {
   func testCompleteGlobalAttributesOnSpansAndLogs() throws {
-    try withSmokeTelemetry { harness in
+    try withSmokeTelemetry(useLegacyAttributeNames: false) { harness in
       let expectedSessionId = SessionManager.instance.session()
       harness.emitSpanAndLog()
       let span = try harness.waitForSpan()
@@ -66,12 +99,15 @@ private final class SmokeTelemetryHarness {
 
   private let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
-  init() {
+  init(useLegacyAttributeNames: Bool) {
     let configuration = AgentConfigBuilder()
       .withExportUrl(URL(string: "https://unused.invalid")!)
       .withRemoteManagement(false)
+      .useLegacyAttributeNames(useLegacyAttributeNames)
       .build()
-    let resource = AgentResource.get().merging(other: AgentEnvResource.get())
+    let resource = AgentResource.get(
+      useLegacyAttributeNames: useLegacyAttributeNames
+    ).merging(other: AgentEnvResource.get())
     let configManager = AgentConfigManager(
       resource: resource,
       config: configuration,
@@ -160,6 +196,7 @@ private struct DirectorySnapshot: Equatable {
 }
 
 private func withSmokeTelemetry(
+  useLegacyAttributeNames: Bool,
   _ test: (SmokeTelemetryHarness) throws -> Void
 ) throws {
   XCTAssertNil(ProcessInfo.processInfo.environment[AgentEnvResource.otelResourceAttributesEnv])
@@ -178,7 +215,8 @@ private func withSmokeTelemetry(
     create: false)
     .appendingPathComponent("elastic", isDirectory: true)
   let initialCaches = DirectorySnapshot(at: cachesDirectory)
-  let harness = SmokeTelemetryHarness()
+  let harness = SmokeTelemetryHarness(
+    useLegacyAttributeNames: useLegacyAttributeNames)
 
   defer {
     harness.shutDown()
@@ -192,7 +230,9 @@ private func withSmokeTelemetry(
   try test(harness)
 }
 
-private func expectedResourceAttributes() throws -> [String: AttributeValue] {
+private func expectedResourceAttributes(
+  useLegacyAttributeNames: Bool
+) throws -> [String: AttributeValue] {
   let application = ApplicationDataSource()
   let device = DeviceDataSource()
   let operatingSystem = OperatingSystemDataSource()
@@ -207,7 +247,11 @@ private func expectedResourceAttributes() throws -> [String: AttributeValue] {
     "os.version": .string(operatingSystem.version),
     "telemetry.sdk.name": .string("iOS"),
     "telemetry.sdk.language": .string("swift"),
-    "telemetry.sdk.version": .string(ElasticApmAgent.elasticSwiftAgentVersion),
+    "telemetry.sdk.version": .string(
+      useLegacyAttributeNames
+        ? "semver:\(ElasticApmAgent.elasticSwiftAgentVersion)"
+        : ElasticApmAgent.elasticSwiftAgentVersion
+    ),
     "process.runtime.name": .string(operatingSystem.name),
     "process.runtime.version": .string(operatingSystem.version)
   ]
@@ -215,7 +259,8 @@ private func expectedResourceAttributes() throws -> [String: AttributeValue] {
   if let build = application.build {
     if let version = application.version {
       expected["service.version"] = .string(version)
-      expected["app.build_id"] = .string(build)
+      expected[useLegacyAttributeNames ? "service.build" : "app.build_id"] =
+        .string(build)
     } else {
       expected["service.version"] = .string(build)
     }

--- a/Sources/Tests/apm-agent-iosTests/TelemetryAttributeSmokeTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/TelemetryAttributeSmokeTests.swift
@@ -23,6 +23,11 @@ import XCTest
 @testable import ElasticApm
 
 final class ResourceAttributeSmokeTests: XCTestCase {
+  @available(*, deprecated)
+  func testDeprecatedServiceBuildConstantRetainsLegacyRawValue() {
+    XCTAssertEqual(ElasticAttributes.serviceBuild.rawValue, "service.build")
+  }
+
   func testCompleteResourceOnSpansLogsAndMetrics() throws {
     try withSmokeTelemetry(useLegacyAttributeNames: false) { harness in
       let expected = try expectedResourceAttributes(useLegacyAttributeNames: false)

--- a/Sources/Tests/apm-agent-iosTests/TelemetryAttributeSmokeTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/TelemetryAttributeSmokeTests.swift
@@ -1,0 +1,233 @@
+// Copyright © 2026 Elasticsearch BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+import ElasticApmTestSupport
+import Foundation
+import NIO
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import ResourceExtension
+import XCTest
+
+@testable import ElasticApm
+
+final class ResourceAttributeSmokeTests: XCTestCase {
+  func testCompleteResourceOnSpansLogsAndMetrics() throws {
+    try withSmokeTelemetry { harness in
+      let expected = try expectedResourceAttributes()
+      harness.emitSpanAndLog()
+      let metric = try harness.emitMetric()
+      let span = try harness.waitForSpan()
+      let log = try harness.waitForLog()
+
+      XCTAssertEqual(span.resource.attributes, expected)
+      XCTAssertEqual(log.resource.attributes, expected)
+      XCTAssertEqual(metric.resource.attributes, expected)
+    }
+  }
+}
+
+final class GlobalSignalAttributeSmokeTests: XCTestCase {
+  func testCompleteGlobalAttributesOnSpansAndLogs() throws {
+    try withSmokeTelemetry { harness in
+      let expectedSessionId = SessionManager.instance.session()
+      harness.emitSpanAndLog()
+      let span = try harness.waitForSpan()
+      let log = try harness.waitForLog()
+
+      XCTAssertEqual(span.attributes["type"], .string("mobile"))
+      XCTAssertEqual(span.attributes["session.id"], .string(expectedSessionId))
+      XCTAssertEqual(log.attributes["session.id"], .string(expectedSessionId))
+
+      #if os(iOS) && !targetEnvironment(macCatalyst)
+        let expectedConnectionType = AttributeValue.string(NetworkStatusManager().status())
+        XCTAssertEqual(span.attributes["network.connection.type"], expectedConnectionType)
+        XCTAssertEqual(log.attributes["network.connection.type"], expectedConnectionType)
+      #endif
+    }
+  }
+}
+
+private final class SmokeTelemetryHarness {
+  let spanExporter = WaitingSpanExporter(numberToWaitFor: 1)
+  let logExporter = WaitingLogRecordExporter(numberToWaitFor: 1)
+  let metricExporter = WaitingMetricExporter(numberToWaitFor: 1)
+
+  private let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+
+  init() {
+    let configuration = AgentConfigBuilder()
+      .withExportUrl(URL(string: "https://unused.invalid")!)
+      .withRemoteManagement(false)
+      .build()
+    let resource = AgentResource.get().merging(other: AgentEnvResource.get())
+    let configManager = AgentConfigManager(
+      resource: resource,
+      config: configuration,
+      instrumentationConfig: InstrumentationConfigBuilder().build())
+    let initializer = OpenTelemetryInitializer(
+      group: group,
+      sessionSampler: SessionSampler { 1.0 },
+      exporters: OpenTelemetryInitializer.Exporters(
+        metric: metricExporter,
+        trace: spanExporter,
+        log: logExporter))
+
+    _ = initializer.initializeWithHttp(configManager)
+  }
+
+  func emitSpanAndLog() {
+    let tracer = OpenTelemetry.instance.tracerProvider.get(
+      instrumentationName: "ResourceAttributeSmokeTests")
+    let span = tracer.spanBuilder(spanName: "attribute-smoke-span").startSpan()
+    span.end()
+
+    let logger = OpenTelemetry.instance.loggerProvider
+      .loggerBuilder(instrumentationScopeName: "ResourceAttributeSmokeTests")
+      .build()
+    logger.logRecordBuilder()
+      .setEventName("attribute-smoke-log")
+      .emit()
+  }
+
+  func waitForSpan() throws -> SpanData {
+    try XCTUnwrap(spanExporter.waitForExport()?.first)
+  }
+
+  func waitForLog() throws -> ReadableLogRecord {
+    try XCTUnwrap(logExporter.waitForExport()?.first)
+  }
+
+  func emitMetric() throws -> MetricData {
+    var counter = OpenTelemetry.instance.meterProvider
+      .get(name: "ResourceAttributeSmokeTests")
+      .counterBuilder(name: "attribute.smoke")
+      .build()
+    counter.add(value: 1)
+
+    let meterProvider = try XCTUnwrap(
+      OpenTelemetry.instance.meterProvider as? MeterProviderSdk)
+    XCTAssertEqual(meterProvider.forceFlush(), .success)
+    return try XCTUnwrap(metricExporter.waitForExport()?.first)
+  }
+
+  func shutDown() {
+    if let tracerProvider = OpenTelemetry.instance.tracerProvider as? TracerProviderSdk {
+      tracerProvider.shutdown()
+    }
+    if let meterProvider = OpenTelemetry.instance.meterProvider as? MeterProviderSdk {
+      XCTAssertEqual(meterProvider.shutdown(), .success)
+    }
+    XCTAssertNoThrow(try group.syncShutdownGracefully())
+  }
+}
+
+private struct DirectorySnapshot: Equatable {
+  let exists: Bool
+  let contents: Set<String>
+
+  init(at directory: URL, fileManager: FileManager = .default) {
+    var isDirectory: ObjCBool = false
+    exists = fileManager.fileExists(atPath: directory.path, isDirectory: &isDirectory)
+      && isDirectory.boolValue
+    guard exists,
+      let enumerator = fileManager.enumerator(
+        at: directory,
+        includingPropertiesForKeys: nil)
+    else {
+      contents = []
+      return
+    }
+
+    contents = Set(enumerator.compactMap { item in
+      guard let url = item as? URL else {
+        return nil
+      }
+      return String(url.path.dropFirst(directory.path.count))
+    })
+  }
+}
+
+private func withSmokeTelemetry(
+  _ test: (SmokeTelemetryHarness) throws -> Void
+) throws {
+  XCTAssertNil(ProcessInfo.processInfo.environment[AgentEnvResource.otelResourceAttributesEnv])
+  XCTAssertNil(
+    Bundle.main.infoDictionary?[AgentEnvResource.otelResourceAttributesEnv],
+    "The smoke tests require an empty OTEL_RESOURCE_ATTRIBUTES overlay")
+
+  let centralConfig = CentralConfig()
+  let previousCentralConfig = centralConfig.config
+  centralConfig.config = nil
+
+  let cachesDirectory = try FileManager.default.url(
+    for: .cachesDirectory,
+    in: .userDomainMask,
+    appropriateFor: nil,
+    create: false)
+    .appendingPathComponent("elastic", isDirectory: true)
+  let initialCaches = DirectorySnapshot(at: cachesDirectory)
+  let harness = SmokeTelemetryHarness()
+
+  defer {
+    harness.shutDown()
+    centralConfig.config = previousCentralConfig
+    XCTAssertEqual(
+      DirectorySnapshot(at: cachesDirectory),
+      initialCaches,
+      "Injected exporters must not create agent persistence files")
+  }
+
+  try test(harness)
+}
+
+private func expectedResourceAttributes() throws -> [String: AttributeValue] {
+  let application = ApplicationDataSource()
+  let device = DeviceDataSource()
+  let operatingSystem = OperatingSystemDataSource()
+  var expected: [String: AttributeValue] = [
+    "service.name": .string(
+      application.name ?? "unknown_service:\(ProcessInfo.processInfo.processName)"),
+    "deployment.environment.name": .string("default"),
+    "device.model.identifier": .string(try XCTUnwrap(device.model)),
+    "os.type": .string(operatingSystem.type),
+    "os.name": .string(operatingSystem.name),
+    "os.description": .string(operatingSystem.description),
+    "os.version": .string(operatingSystem.version),
+    "telemetry.sdk.name": .string("iOS"),
+    "telemetry.sdk.language": .string("swift"),
+    "telemetry.sdk.version": .string(ElasticApmAgent.elasticSwiftAgentVersion),
+    "process.runtime.name": .string(operatingSystem.name),
+    "process.runtime.version": .string(operatingSystem.version)
+  ]
+
+  if let build = application.build {
+    if let version = application.version {
+      expected["service.version"] = .string(version)
+      expected["app.build_id"] = .string(build)
+    } else {
+      expected["service.version"] = .string(build)
+    }
+  } else if let version = application.version {
+    expected["service.version"] = .string(version)
+  }
+
+  #if os(macOS)
+    XCTAssertNil(device.identifier)
+  #else
+    expected["device.id"] = .string(try XCTUnwrap(device.identifier))
+  #endif
+
+  return expected
+}

--- a/Sources/Tests/apm-agent-iosTests/TransactionHelperTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/TransactionHelperTests.swift
@@ -1,0 +1,37 @@
+// Copyright © 2026 Elasticsearch BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import XCTest
+
+@testable import ElasticApm
+
+final class TransactionHelperTests: XCTestCase {
+  func testHTTPSpanDetectionAcceptsStableAndLegacyURLKeys() throws {
+    XCTAssertTrue(try makeSpan(attributeName: "url.full").isHttpSpan())
+    XCTAssertTrue(try makeSpan(attributeName: "http.url").isHttpSpan())
+    XCTAssertFalse(try makeSpan(attributeName: "url.path").isHttpSpan())
+  }
+
+  private func makeSpan(attributeName: String) throws -> any ReadableSpan {
+    let tracer = TracerProviderBuilder()
+      .build()
+      .get(instrumentationName: "TransactionHelperTests")
+    let span = tracer.spanBuilder(spanName: "test-span")
+      .setAttribute(key: attributeName, value: .string("https://example.com"))
+      .startSpan()
+    return try XCTUnwrap(span as? any ReadableSpan)
+  }
+}

--- a/Sources/Tests/cpu-sampler-tests/CPUSamplerTests.swift
+++ b/Sources/Tests/cpu-sampler-tests/CPUSamplerTests.swift
@@ -33,7 +33,13 @@ final class CPUSamplerTests: XCTestCase {
     XCTAssertEqual(point.value, 0.5, accuracy: 0.000_001)
     XCTAssertGreaterThanOrEqual(point.value, 0)
     XCTAssertLessThanOrEqual(point.value, 1)
-    XCTAssertTrue(point.attributes.isEmpty)
+    XCTAssertEqual(metric.unit, "1")
+    XCTAssertEqual(
+      point.attributes,
+      [
+        SemanticConventions.Cpu.mode.rawValue:
+          .string(SemanticConventions.Cpu.ModeValues("total").description)
+      ])
     XCTAssertNil(point.attributes["state"])
   }
 
@@ -45,6 +51,7 @@ final class CPUSamplerTests: XCTestCase {
     XCTAssertNotEqual(metric.name, "process.cpu.utilization")
     XCTAssertEqual(point.value, percentSum, accuracy: 0.000_001)
     XCTAssertGreaterThan(point.value, 1)
+    XCTAssertEqual(metric.unit, "")
     XCTAssertEqual(point.attributes, ["state": .string("app")])
   }
 

--- a/Sources/Tests/cpu-sampler-tests/CPUSamplerTests.swift
+++ b/Sources/Tests/cpu-sampler-tests/CPUSamplerTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 Elasticsearch BV
+// Copyright © 2026 Elasticsearch BV
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -13,31 +13,38 @@
 //   limitations under the License.
 
 import ElasticApmTestSupport
+import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
 import XCTest
 
-@testable import MemorySampler
+@testable import CPUSampler
 
-final class MemorySamplerTests: XCTestCase {
-  func testDefaultMetricUsesProcessNameWithoutLegacyState() throws {
+final class CPUSamplerTests: XCTestCase {
+  private let percentSum =
+    Double(ProcessInfo.processInfo.activeProcessorCount) * 50.0
+
+  func testDefaultMetricUsesProcessRatioWithoutLegacyState() throws {
     let metric = try collectMetric(useLegacyAttributeNames: false)
     let point = try XCTUnwrap(metric.data.points.first as? DoublePointData)
 
-    XCTAssertEqual(metric.name, "process.memory.usage")
-    XCTAssertNotEqual(metric.name, "system.memory.usage")
-    XCTAssertEqual(point.value, 4_096)
+    XCTAssertEqual(metric.name, "process.cpu.utilization")
+    XCTAssertNotEqual(metric.name, "system.cpu.usage")
+    XCTAssertEqual(point.value, 0.5, accuracy: 0.000_001)
+    XCTAssertGreaterThanOrEqual(point.value, 0)
+    XCTAssertLessThanOrEqual(point.value, 1)
     XCTAssertTrue(point.attributes.isEmpty)
     XCTAssertNil(point.attributes["state"])
   }
 
-  func testLegacyMetricRestoresSystemNameAndState() throws {
+  func testLegacyMetricRestoresPercentSumNameAndState() throws {
     let metric = try collectMetric(useLegacyAttributeNames: true)
     let point = try XCTUnwrap(metric.data.points.first as? DoublePointData)
 
-    XCTAssertEqual(metric.name, "system.memory.usage")
-    XCTAssertNotEqual(metric.name, "process.memory.usage")
-    XCTAssertEqual(point.value, 4_096)
+    XCTAssertEqual(metric.name, "system.cpu.usage")
+    XCTAssertNotEqual(metric.name, "process.cpu.utilization")
+    XCTAssertEqual(point.value, percentSum, accuracy: 0.000_001)
+    XCTAssertGreaterThan(point.value, 1)
     XCTAssertEqual(point.attributes, ["state": .string("app")])
   }
 
@@ -56,9 +63,9 @@ final class MemorySamplerTests: XCTestCase {
       .build()
     OpenTelemetry.registerMeterProvider(meterProvider: provider)
 
-    let sampler = MemorySampler(
+    let sampler = CPUSampler(
       useLegacyAttributeNames: useLegacyAttributeNames,
-      memoryFootprint: { 4_096 }
+      cpuFootprint: { self.percentSum }
     )
     let metric = try withExtendedLifetime(sampler) {
       XCTAssertEqual(provider.forceFlush(), .success)

--- a/Sources/Tests/memory-sampler-tests/MemorySamplerTests.swift
+++ b/Sources/Tests/memory-sampler-tests/MemorySamplerTests.swift
@@ -27,6 +27,11 @@ final class MemorySamplerTests: XCTestCase {
     XCTAssertEqual(metric.name, "process.memory.usage")
     XCTAssertNotEqual(metric.name, "system.memory.usage")
     XCTAssertEqual(point.value, 4_096)
+    XCTAssertEqual(metric.unit, "By")
+    guard case .DoubleSum = metric.type else {
+      return XCTFail("process.memory.usage must use an UpDownCounter")
+    }
+    XCTAssertFalse(metric.isMonotonic)
     XCTAssertTrue(point.attributes.isEmpty)
     XCTAssertNil(point.attributes["state"])
   }
@@ -38,6 +43,10 @@ final class MemorySamplerTests: XCTestCase {
     XCTAssertEqual(metric.name, "system.memory.usage")
     XCTAssertNotEqual(metric.name, "process.memory.usage")
     XCTAssertEqual(point.value, 4_096)
+    XCTAssertEqual(metric.unit, "")
+    guard case .DoubleGauge = metric.type else {
+      return XCTFail("Legacy system.memory.usage must remain a gauge")
+    }
     XCTAssertEqual(point.attributes, ["state": .string("app")])
   }
 

--- a/Sources/apm-agent-ios/AgentConfigBuilder.swift
+++ b/Sources/apm-agent-ios/AgentConfigBuilder.swift
@@ -29,6 +29,7 @@ public class AgentConfigBuilder {
   private static let api = "ApiKey"
   private var connectionType: AgentConnectionType = .http
   private var sampleRate = 1.0
+  private var legacyAttributeNames = false
 
   private var spanFilters = [SignalFilter<ReadableSpan>]()
   private var logFilters = [SignalFilter<ReadableLogRecord>]()
@@ -78,6 +79,11 @@ public class AgentConfigBuilder {
     return self
   }
 
+  public func useLegacyAttributeNames(_ enabled: Bool) -> Self {
+    legacyAttributeNames = enabled
+    return self
+  }
+
   public func useOpAMP() -> Self {
     enableOpAPM = true
     return self
@@ -122,6 +128,7 @@ public class AgentConfigBuilder {
     config.connectionType = connectionType
     config.managementUrl = self.managementUrl
     config.enableRemoteManagement = enableRemoteManagement
+    config.useLegacyAttributeNames = legacyAttributeNames
 
     if !self.spanAttributeInterceptors.isEmpty {
       if self.spanAttributeInterceptors.count > 1 {

--- a/Sources/apm-agent-ios/AgentConfiguration.swift
+++ b/Sources/apm-agent-ios/AgentConfiguration.swift
@@ -91,6 +91,7 @@ public struct AgentConfiguration {
   public var connectionType: AgentConnectionType = .http
   var auth: String?
   var sampleRate: Double = 1.0
+  var useLegacyAttributeNames = false
 
   var spanFilters = [SignalFilter<ReadableSpan>]()
   var logFilters = [SignalFilter<ReadableLogRecord>]()

--- a/Sources/apm-agent-ios/AgentResource.swift
+++ b/Sources/apm-agent-ios/AgentResource.swift
@@ -34,7 +34,7 @@ public class AgentResource {
 
     let osDataSource = OperatingSystemDataSource()
     overridingAttributes[SemanticConventions.Telemetry.sdkVersion.rawValue] =
-      AttributeValue.string("semver:\(ElasticApmAgent.elasticSwiftAgentVersion)")
+      AttributeValue.string(ElasticApmAgent.elasticSwiftAgentVersion)
     overridingAttributes[SemanticConventions.Process.runtimeName.rawValue] = AttributeValue
       .string(osDataSource.name)
     overridingAttributes[SemanticConventions.Process.runtimeVersion.rawValue] =

--- a/Sources/apm-agent-ios/AgentResource.swift
+++ b/Sources/apm-agent-ios/AgentResource.swift
@@ -26,6 +26,10 @@ import OpenTelemetrySdk
 
 public class AgentResource {
   public static func get() -> Resource {
+    get(useLegacyAttributeNames: false)
+  }
+
+  static func get(useLegacyAttributeNames: Bool) -> Resource {
     let defaultResource = DefaultResources().get()
     var overridingAttributes = [
       SemanticConventions.Telemetry.sdkName.rawValue: AttributeValue
@@ -34,7 +38,12 @@ public class AgentResource {
 
     let osDataSource = OperatingSystemDataSource()
     overridingAttributes[SemanticConventions.Telemetry.sdkVersion.rawValue] =
-      AttributeValue.string(ElasticApmAgent.elasticSwiftAgentVersion)
+      AttributeValue.string(
+        useLegacyAttributeNames
+          ? LegacyAttributeNames.telemetrySDKVersionPrefix
+            + ElasticApmAgent.elasticSwiftAgentVersion
+          : ElasticApmAgent.elasticSwiftAgentVersion
+      )
     overridingAttributes[SemanticConventions.Process.runtimeName.rawValue] = AttributeValue
       .string(osDataSource.name)
     overridingAttributes[SemanticConventions.Process.runtimeVersion.rawValue] =
@@ -49,7 +58,11 @@ public class AgentResource {
       if let version = appDataSource.version {
         overridingAttributes[SemanticConventions.Service.version.rawValue] = AttributeValue
           .string(version)
-        overridingAttributes[ElasticAttributes.serviceBuild.rawValue] = AttributeValue.string(build)
+        overridingAttributes[
+          useLegacyAttributeNames
+            ? LegacyAttributeNames.serviceBuild
+            : SemanticConventions.App.buildId.rawValue
+        ] = AttributeValue.string(build)
       } else {
         overridingAttributes[SemanticConventions.Service.version.rawValue] = AttributeValue
           .string(build)

--- a/Sources/apm-agent-ios/ElasticApmAgent.swift
+++ b/Sources/apm-agent-ios/ElasticApmAgent.swift
@@ -78,6 +78,10 @@ public class ElasticApmAgent {
   private init(
     configuration: AgentConfiguration, instrumentationConfiguration: InstrumentationConfiguration
   ) {
+    let resource = AgentResource.get(
+      useLegacyAttributeNames: configuration.useLegacyAttributeNames
+    ).merging(other: AgentEnvResource.get())
+
     crashConfig.sessionId = SessionManager.instance.session(false)
     #if os(iOS) && !targetEnvironment(macCatalyst)
       crashConfig.networkStatus = NetworkStatusManager().lastStatus
@@ -85,7 +89,7 @@ public class ElasticApmAgent {
 
     _ = SessionManager.instance.session()  // initialize session
     agentConfigManager = AgentConfigManager(
-      resource: AgentResource.get().merging(other: AgentEnvResource.get()),
+      resource: resource,
  config: configuration,
       instrumentationConfig: instrumentationConfiguration,
       logger: Logging.Logger(label: "Elastic.ConfigManager")
@@ -112,8 +116,9 @@ public class ElasticApmAgent {
     #if !os(watchOS)
     if instrumentationConfiguration.enableCrashReporting {
       crashManager = CrashManager(
-        resource: AgentResource.get().merging(other: AgentEnvResource.get()),
-        logExporter: crashLogExporter)
+        resource: resource,
+        logExporter: crashLogExporter,
+        useLegacyAttributeNames: configuration.useLegacyAttributeNames)
     } else {
       crashManager = nil
     }

--- a/Sources/apm-agent-ios/ElasticAttributes.swift
+++ b/Sources/apm-agent-ios/ElasticAttributes.swift
@@ -14,18 +14,43 @@
 
 import Foundation
 
+@available(
+  *,
+  deprecated,
+  message: "Use OpenTelemetryApi.SemanticConventions constants instead."
+)
 public enum ElasticAttributes: String {
   /**
    Timestamp applied to all spans at time of export. To help with clock drift.
     */
+  @available(
+    *,
+    deprecated,
+    message: "No SemanticConventions attribute replaces this value; use OpenTelemetry signal timestamps."
+  )
   case exportTimestamp = "telemetry.sdk.elastic_export_timestamp"
 
   /**
    The id of the device
     */
+  @available(
+    *,
+    deprecated,
+    message: "Use SemanticConventions.Device.id."
+  )
   case deviceIdentifier = "device.id"
 
+  @available(
+    *,
+    deprecated,
+    message: "Use SemanticConventions.Session.id."
+  )
   case sessionId = "session.id"
 
+  @available(
+    *,
+    deprecated,
+    message: "Use SemanticConventions.App.buildId."
+  )
   case serviceBuild = "app.build_id"
 }

--- a/Sources/apm-agent-ios/ElasticAttributes.swift
+++ b/Sources/apm-agent-ios/ElasticAttributes.swift
@@ -52,5 +52,5 @@ public enum ElasticAttributes: String {
     deprecated,
     message: "Use SemanticConventions.App.buildId."
   )
-  case serviceBuild = "app.build_id"
+  case serviceBuild = "service.build"
 }

--- a/Sources/apm-agent-ios/ElasticAttributes.swift
+++ b/Sources/apm-agent-ios/ElasticAttributes.swift
@@ -27,5 +27,5 @@ public enum ElasticAttributes: String {
 
   case sessionId = "session.id"
 
-  case serviceBuild = "service.build"
+  case serviceBuild = "app.build_id"
 }

--- a/Sources/apm-agent-ios/Instrumentation/CrashReporting/CrashManager.swift
+++ b/Sources/apm-agent-ios/Instrumentation/CrashReporting/CrashManager.swift
@@ -24,14 +24,20 @@ import os.log
 
 #if !os(watchOS)
 struct CrashManager {
-  static let crashEventName: String = "crash"
+  static let crashEventName = "app.crash"
   static let crashManagerVersion = "0.0.3"
   static let lastResourceDefaultsKey: String = "elastic.last.resource"
   static let instrumentationName = "PLCrashReporter"
+  let eventName: String
   let lastResource: Resource
   let loggerProvider: LoggerProvider
   private let logger = OSLog(subsystem: "co.elastic.crash-reporter", category: "instrumentation")
-  init(resource: Resource, logExporter: LogRecordExporter) {
+  init(
+    resource: Resource,
+    logExporter: LogRecordExporter,
+    useLegacyAttributeNames: Bool = false
+  ) {
+    eventName = Self.eventName(useLegacyAttributeNames: useLegacyAttributeNames)
     // if something went wrong with the lastResource in the user defaults, fallback of the current resource data.
     var tempResource = resource
 
@@ -127,7 +133,7 @@ struct CrashManager {
           }
 
             logger.logRecordBuilder()
-                .setEventName(Self.crashEventName)
+                .setEventName(eventName)
                 .setSeverity(.fatal)
                 .setObservedTimestamp(report.systemInfo.timestamp)
                 .setAttributes(attributes)
@@ -149,7 +155,10 @@ struct CrashManager {
     crashReporter.purgePendingCrashReport()
   }
 
-  
+  static func eventName(useLegacyAttributeNames: Bool) -> String {
+    useLegacyAttributeNames ? LegacyAttributeNames.crashEvent : crashEventName
+  }
+
   private func getSignalHandler() -> PLCrashReporterSignalHandlerType {
     #if os(tvOS)
       return .BSD

--- a/Sources/apm-agent-ios/Instrumentation/Lifecycle/ApplicationLifecycleInstrumentation.swift
+++ b/Sources/apm-agent-ios/Instrumentation/Lifecycle/ApplicationLifecycleInstrumentation.swift
@@ -17,14 +17,10 @@ import Foundation
 import UIKit
 import OpenTelemetryApi
 public class ApplicationLifecycleInstrumentation: NSObject {
-    private static let eventName: String = "lifecycle"
-    private enum State: String {
-        case active
-        case inactive
-        case background
-        case foreground
-        case terminate
-}
+    // https://opentelemetry.io/docs/specs/semconv/mobile/mobile-events/
+    private static let eventName = "device.app.lifecycle"
+    private let useLegacyAttributeNames: Bool
+
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
@@ -38,8 +34,18 @@ public class ApplicationLifecycleInstrumentation: NSObject {
     }
 
     public override init() {
+        useLegacyAttributeNames = false
         super.init()
+        registerObservers()
+    }
 
+    init(useLegacyAttributeNames: Bool) {
+        self.useLegacyAttributeNames = useLegacyAttributeNames
+        super.init()
+        registerObservers()
+    }
+
+    private func registerObservers() {
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(active(_:)),
                                                name: UIApplication.didBecomeActiveNotification,
@@ -67,38 +73,38 @@ public class ApplicationLifecycleInstrumentation: NSObject {
     }
 
     @objc func active(_ notification: Notification) {
-        Self.getLogger().logRecordBuilder()
-            .setEventName(Self.eventName)
-            .setAttributes(["lifecycle.state": AttributeValue.string(State.active.rawValue)])
-            .emit()
+        emit(state: .active)
     }
 
     @objc func inactive(_ notification: Notification) {
-        Self.getLogger().logRecordBuilder()
-            .setEventName(Self.eventName)
-            .setAttributes(["lifecycle.state": AttributeValue.string(State.inactive.rawValue)])
-            .emit()
+        emit(state: .inactive)
     }
 
     @objc func background(_ notification: Notification) {
-        Self.getLogger().logRecordBuilder()
-            .setEventName(Self.eventName)
-            .setAttributes(["lifecycle.state": AttributeValue.string(State.background.rawValue)])
-            .emit()
+        emit(state: .background)
     }
 
     @objc func foreground(_ notification: Notification) {
-        Self.getLogger().logRecordBuilder()
-            .setEventName(Self.eventName)
-            .setAttributes(["lifecycle.state": AttributeValue.string(State.foreground.rawValue)])
-            .emit()
+        emit(state: .foreground)
     }
 
     @objc func terminate(_ notification: Notification) {
+        emit(state: .terminate)
+    }
+
+    private func emit(state: SemanticConventions.Ios.AppStateValues) {
+        let eventName = useLegacyAttributeNames
+            ? LegacyAttributeNames.lifecycleEvent
+            : Self.eventName
+        let stateAttribute = useLegacyAttributeNames
+            ? LegacyAttributeNames.lifecycleState
+            : SemanticConventions.Ios.appState.rawValue
+
         Self.getLogger().logRecordBuilder()
-            .setEventName(Self.eventName)
-            .setAttributes(["lifecycle.state": AttributeValue.string(State.terminate.rawValue)])
-            .emit()}
+            .setEventName(eventName)
+            .setAttributes([stateAttribute: AttributeValue.string(state.description)])
+            .emit()
+    }
 }
 
 #endif

--- a/Sources/apm-agent-ios/InstrumentationWrapper.swift
+++ b/Sources/apm-agent-ios/InstrumentationWrapper.swift
@@ -29,6 +29,8 @@ class InstrumentationWrapper {
   #endif
 
   var urlSessionInstrumentation: URLSessionInstrumentation?
+  var memorySampler: MemorySampler?
+  var cpuSampler: CPUSampler?
   let config: AgentConfigManager
 
   init(config: AgentConfigManager) {
@@ -36,7 +38,8 @@ class InstrumentationWrapper {
 
     #if os(iOS)
       if config.instrumentation.enableLifecycleEvents {
-        applicationLifecycleInstrumentation = ApplicationLifecycleInstrumentation()
+        applicationLifecycleInstrumentation = ApplicationLifecycleInstrumentation(
+          useLegacyAttributeNames: config.agent.useLegacyAttributeNames)
       }
       do {
         if self.config.instrumentation.enableViewControllerInstrumentation {
@@ -52,8 +55,10 @@ class InstrumentationWrapper {
     #if os(iOS)
       if #available(iOS 13.0, *) {
         if config.instrumentation.enableSystemMetrics {
-          _ = MemorySampler()
-          _ = CPUSampler()
+          memorySampler = MemorySampler(
+            useLegacyAttributeNames: config.agent.useLegacyAttributeNames)
+          cpuSampler = CPUSampler(
+            useLegacyAttributeNames: config.agent.useLegacyAttributeNames)
         }
       }
     #endif
@@ -75,7 +80,14 @@ class InstrumentationWrapper {
       }
     #endif
 
-    let config = URLSessionInstrumentationConfiguration(
+    let configuration = makeURLSessionInstrumentationConfiguration()
+
+    urlSessionInstrumentation = URLSessionInstrumentation(configuration: configuration)
+  }
+
+  func makeURLSessionInstrumentationConfiguration()
+    -> URLSessionInstrumentationConfiguration {
+    URLSessionInstrumentationConfiguration(
       shouldRecordPayload: nil,
       shouldInstrument: nil,
 
@@ -143,9 +155,8 @@ class InstrumentationWrapper {
             ]
           )
         // swiftlint:enable line_length
-      }
+      },
+      semanticConvention: config.agent.useLegacyAttributeNames ? .old : .stable
     )
-
-    urlSessionInstrumentation = URLSessionInstrumentation(configuration: config)
   }
 }

--- a/Sources/apm-agent-ios/LegacyAttributeNames.swift
+++ b/Sources/apm-agent-ios/LegacyAttributeNames.swift
@@ -1,0 +1,21 @@
+// Copyright © 2026 Elasticsearch BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+enum LegacyAttributeNames {
+  static let crashEvent = "crash"
+  static let lifecycleEvent = "lifecycle"
+  static let lifecycleState = "lifecycle.state"
+  static let serviceBuild = "service.build"
+  static let telemetrySDKVersionPrefix = "semver:"
+}

--- a/Sources/apm-agent-ios/OpenTelementry Extensions/ElasticLogRecordProcessor.swift
+++ b/Sources/apm-agent-ios/OpenTelementry Extensions/ElasticLogRecordProcessor.swift
@@ -33,7 +33,7 @@ public struct ElasticLogRecordProcessor: LogRecordProcessor {
     self.attributeInterceptor = configuration.logRecordAttributeInterceptor
       .join { attributes in
           var newAttributes = attributes
-          newAttributes[ElasticAttributes.sessionId.rawValue] = .string(
+          newAttributes[SemanticConventions.Session.id.rawValue] = .string(
             SessionManager.instance.session())
           return newAttributes
         }

--- a/Sources/apm-agent-ios/OpenTelementry Extensions/ElasticSpanProcessor.swift
+++ b/Sources/apm-agent-ios/OpenTelementry Extensions/ElasticSpanProcessor.swift
@@ -68,7 +68,8 @@ public struct ElasticSpanProcessor: SpanProcessor {
       }
       .join { attributes in
         var newAttributes = attributes
-        newAttributes[ElasticAttributes.sessionId.rawValue] = .string(SessionManager.instance.session())
+        newAttributes[SemanticConventions.Session.id.rawValue] = .string(
+          SessionManager.instance.session())
         return newAttributes
       }
   }
@@ -105,7 +106,7 @@ public struct ElasticSpanProcessor: SpanProcessor {
         newAttributes.updateValue(value: .string("mobile"), forKey: "type")
         newAttributes.updateValue(
           value: AttributeValue.string(SessionManager.instance.session()),
-          forKey: ElasticAttributes.sessionId.rawValue)
+          forKey: SemanticConventions.Session.id.rawValue)
         let parentSpanContext = SpanContext.create(
           traceId: span.context.traceId, spanId: SpanId.random(), traceFlags: TraceFlags(),
           traceState: TraceState())

--- a/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
+++ b/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
@@ -24,9 +24,14 @@ import OpenTelemetrySdk
 import PersistenceExporter
 import os
 
-
 class OpenTelemetryInitializer {
   static let logLabel = "Elastic-OTLP-Exporter"
+
+  struct Exporters {
+    let metric: MetricExporter
+    let trace: SpanExporter
+    let log: LogRecordExporter
+  }
 
   enum PersistenceSignal: String, CaseIterable {
     case logs
@@ -36,6 +41,7 @@ class OpenTelemetryInitializer {
 
   let group: EventLoopGroup
   let sessionSampler: SessionSampler
+  let exporters: Exporters?
 
   static func createPersistenceFolder(
     for signal: PersistenceSignal,
@@ -111,9 +117,14 @@ class OpenTelemetryInitializer {
     }
   }
 
-  init(group: EventLoopGroup, sessionSampler: SessionSampler) {
+  init(
+    group: EventLoopGroup,
+    sessionSampler: SessionSampler,
+    exporters: Exporters? = nil
+  ) {
     self.group = group
     self.sessionSampler = sessionSampler
+    self.exporters = exporters
   }
 
   // swiftlint:disable:next function_body_length
@@ -134,6 +145,14 @@ class OpenTelemetryInitializer {
     traceSampleFilter.append(contentsOf: configuration.agent.spanFilters)
     logSampleFliter.append(contentsOf: configuration.agent.logFilters)
 
+    let resources = AgentResource.get().merging(other: AgentEnvResource.get())
+    if let exporters {
+      return registerProviders(
+        configuration: configuration,
+        resources: resources,
+        exporters: exporters)
+    }
+
     let otlpConfiguration = OtlpConfiguration(
       timeout: OtlpConfiguration.DefaultTimeoutInterval,
       headers: OpenTelemetryHelper.generateExporterHeaders(configuration.agent.auth))
@@ -147,7 +166,6 @@ class OpenTelemetryInitializer {
     }
     let channel = OpenTelemetryHelper.makeChannel(target: channelTarget, group: group)
 
-    let resources = AgentResource.get().merging(other: AgentEnvResource.get())
     let metricExporter = {
       let defaultExporter = OtlpMetricExporter(
         channel: channel, config: otlpConfiguration, logger: Logger(label: Self.logLabel))
@@ -191,55 +209,16 @@ class OpenTelemetryInitializer {
       return defaultExporter as LogRecordExporter
     }()
 
-    // initialize meter provider
-    OpenTelemetry.registerMeterProvider(
-      meterProvider: MeterProviderSdk.builder()
-        .registerView(
-          selector: InstrumentSelector
-            .builder()
-            .setInstrument(name: ".*")
-            .build(),
-          view: View.builder().build()
-        )
-        .registerMetricReader(
-          reader: PeriodicMetricReaderBuilder(
-            exporter: metricExporter
-          ).build())
-        .build())
-
-    // initialize trace provider
-    OpenTelemetry.registerTracerProvider(
-      tracerProvider: TracerProviderBuilder()
-        .add(
-          spanProcessor: ElasticSpanProcessor(
-            spanExporter: traceExporter, agentConfiguration: configuration.agent)
-        )
-        .with(sampler: sessionSampler as Sampler)
-        .with(resource: resources)
-        .with(clock: NTPClock())
-        .build())
-
-    OpenTelemetry.registerLoggerProvider(
-      loggerProvider: LoggerProviderBuilder()
-        .with(clock: NTPClock())
-        .with(resource: resources)
-        .with(processors: [
-          ElasticLogRecordProcessor(
-            logRecordExporter: logExporter,
-            configuration: configuration.agent)
-        ])
-        .build())
-
-    return logExporter
+    return registerProviders(
+      configuration: configuration,
+      resources: resources,
+      exporters: Exporters(
+        metric: metricExporter,
+        trace: traceExporter,
+        log: logExporter))
   }
 
-
   func initializeWithHttp(_ configuration: AgentConfigManager) -> LogRecordExporter {
-    guard let endpoint =  OpenTelemetryHelper.getURL(with: configuration.agent) else {
-      os_log("Failed to start Elastic agent: invalid collector url.")
-      return NoopLogRecordExporter.instance
-    }
-
     var traceSampleFilter: [SignalFilter<any ReadableSpan>] = [
       SignalFilter<any ReadableSpan>({ [self] _ in
         self.sessionSampler.shouldSample
@@ -255,11 +234,23 @@ class OpenTelemetryInitializer {
     traceSampleFilter.append(contentsOf: configuration.agent.spanFilters)
     logSampleFliter.append(contentsOf: configuration.agent.logFilters)
 
+    let resources = AgentResource.get().merging(other: AgentEnvResource.get())
+    if let exporters {
+      return registerProviders(
+        configuration: configuration,
+        resources: resources,
+        exporters: exporters)
+    }
+
+    guard let endpoint =  OpenTelemetryHelper.getURL(with: configuration.agent) else {
+      os_log("Failed to start Elastic agent: invalid collector url.")
+      return NoopLogRecordExporter.instance
+    }
+
     let otlpConfiguration = OtlpConfiguration(
       timeout: OtlpConfiguration.DefaultTimeoutInterval,
       headers: OpenTelemetryHelper.generateExporterHeaders(configuration.agent.auth))
 
-    let resources = AgentResource.get().merging(other: AgentEnvResource.get())
     let metricExporter = {
       let metricEndpoint = URL(string: endpoint.absoluteString + "/v1/metrics")
       let defaultExporter = OtlpHttpMetricExporter(endpoint: metricEndpoint ?? endpoint, config: otlpConfiguration)
@@ -275,7 +266,8 @@ class OpenTelemetryInitializer {
 
     let traceExporter = {
       let traceEndpoint = URL(string: endpoint.absoluteString + "/v1/traces")
-      let defaultExporter = OtlpHttpTraceExporter(endpoint: traceEndpoint ?? endpoint, config:otlpConfiguration)
+      let defaultExporter = OtlpHttpTraceExporter(
+        endpoint: traceEndpoint ?? endpoint, config: otlpConfiguration)
       do {
         if let path = Self.createPersistenceFolder(for: .traces) {
           return try PersistenceSpanExporterDecorator(
@@ -302,27 +294,41 @@ class OpenTelemetryInitializer {
       return defaultExporter as LogRecordExporter
     }()
 
-OpenTelemetry.registerMeterProvider(
-    meterProvider: MeterProviderSdk.builder()
-      .registerView(
-        selector: InstrumentSelector
-          .builder()
-          .setInstrument(name: ".*")
-          .build(),
-        view: View.builder().build()
-      )
-      .registerMetricReader(
-        reader: PeriodicMetricReaderBuilder(
-          exporter: metricExporter
-        ).build()
-      ).build())
+    return registerProviders(
+      configuration: configuration,
+      resources: resources,
+      exporters: Exporters(
+        metric: metricExporter,
+        trace: traceExporter,
+        log: logExporter))
+  }
 
-    // initialize trace provider
+  private func registerProviders(
+    configuration: AgentConfigManager,
+    resources: Resource,
+    exporters: Exporters
+  ) -> LogRecordExporter {
+    OpenTelemetry.registerMeterProvider(
+      meterProvider: MeterProviderSdk.builder()
+        .setResource(resource: resources)
+        .registerView(
+          selector: InstrumentSelector
+            .builder()
+            .setInstrument(name: ".*")
+            .build(),
+          view: View.builder().build()
+        )
+        .registerMetricReader(
+          reader: PeriodicMetricReaderBuilder(
+            exporter: exporters.metric
+          ).build()
+        ).build())
+
     OpenTelemetry.registerTracerProvider(
       tracerProvider: TracerProviderBuilder()
         .add(
           spanProcessor: ElasticSpanProcessor(
-            spanExporter: traceExporter, agentConfiguration: configuration.agent)
+            spanExporter: exporters.trace, agentConfiguration: configuration.agent)
         )
         .with(sampler: sessionSampler as Sampler)
         .with(resource: resources)
@@ -335,10 +341,10 @@ OpenTelemetry.registerMeterProvider(
         .with(resource: resources)
         .with(processors: [
           ElasticLogRecordProcessor(
-            logRecordExporter: logExporter,
+            logRecordExporter: exporters.log,
             configuration: configuration.agent)
         ])
         .build())
-    return logExporter
+    return exporters.log
   }
 }

--- a/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
+++ b/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
@@ -145,7 +145,9 @@ class OpenTelemetryInitializer {
     traceSampleFilter.append(contentsOf: configuration.agent.spanFilters)
     logSampleFliter.append(contentsOf: configuration.agent.logFilters)
 
-    let resources = AgentResource.get().merging(other: AgentEnvResource.get())
+    let resources = AgentResource.get(
+      useLegacyAttributeNames: configuration.agent.useLegacyAttributeNames
+    ).merging(other: AgentEnvResource.get())
     if let exporters {
       return registerProviders(
         configuration: configuration,
@@ -234,7 +236,9 @@ class OpenTelemetryInitializer {
     traceSampleFilter.append(contentsOf: configuration.agent.spanFilters)
     logSampleFliter.append(contentsOf: configuration.agent.logFilters)
 
-    let resources = AgentResource.get().merging(other: AgentEnvResource.get())
+    let resources = AgentResource.get(
+      useLegacyAttributeNames: configuration.agent.useLegacyAttributeNames
+    ).merging(other: AgentEnvResource.get())
     if let exporters {
       return registerProviders(
         configuration: configuration,

--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -187,6 +187,60 @@ Refer to [Central configuration](#central-configuration) for the complete setup.
 
 Controls whether EDOT iOS contacts central configuration for runtime configuration updates. Set it to `false` to turn off remote management entirely.
 
+### Telemetry attribute compatibility [telemetry-attribute-compatibility]
+
+EDOT iOS emits current OpenTelemetry semantic-convention names by default.
+
+#### `useLegacyAttributeNames(_:)` [useLegacyAttributeNames]
+
+| Type | Default |
+| --- | --- |
+| `Bool` | `false` |
+
+Restores the telemetry names emitted before the semantic-convention cleanup.
+Use this temporary compatibility option only while dashboards, alerts, or other
+consumers migrate to the current names:
+
+```swift
+let configuration = AgentConfigBuilder()
+  .withExportUrl(URL(string: "https://your-otlp-endpoint")!)
+  .useLegacyAttributeNames(true)
+  .build()
+```
+
+When enabled, this option restores all of the following legacy output:
+
+- URLSession spans use the old HTTP attributes such as `http.method`,
+  `http.url`, and `http.status_code` instead of stable HTTP attributes.
+- Application lifecycle events use `lifecycle` and `lifecycle.state` instead
+  of `device.app.lifecycle` and `ios.app.state`.
+- CPU and memory gauges use `system.cpu.usage` and `system.memory.usage` with
+  `state` set to `app`. CPU values use the previous percent-sum scale instead
+  of the `process.cpu.utilization` ratio.
+- Crash log records use the `crash` event name instead of `app.crash`.
+- Build identity uses `service.build` instead of `app.build_id`, and
+  `telemetry.sdk.version` uses the previous `semver:` prefix.
+
+The option changes only these compatibility names and the CPU value coupled to
+its metric name. It does not disable other fixes or instrumentation.
+
+#### Deprecated `ElasticAttributes` constants [deprecated-elastic-attributes]
+
+`ElasticAttributes` and all of its cases are deprecated in source after EDOT
+iOS 2.0.2. New integrations must use the upstream OpenTelemetry semantic
+convention constants:
+
+- Replace `ElasticAttributes.deviceIdentifier` with
+  `SemanticConventions.Device.id`.
+- Replace `ElasticAttributes.sessionId` with
+  `SemanticConventions.Session.id`.
+- Replace `ElasticAttributes.serviceBuild` with
+  `SemanticConventions.App.buildId`.
+- `ElasticAttributes.exportTimestamp` has no semantic-convention attribute
+  replacement. Use the timestamps carried by OpenTelemetry signals.
+
+The deprecated enum remains available for source compatibility.
+
 ### Session behavior [session-behavior]
 
 EDOT iOS makes a span sampling decision when a new app session begins.

--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -249,7 +249,7 @@ convention constants:
 - `ElasticAttributes.exportTimestamp` has no semantic-convention attribute
   replacement. Use the timestamps carried by OpenTelemetry signals.
 
-The deprecated enum remains available for source compatibility.
+The deprecated `enum` remains available for source compatibility.
 
 ### Session behavior [session-behavior]
 

--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -189,6 +189,11 @@ Controls whether EDOT iOS contacts central configuration for runtime configurati
 
 ### Telemetry attribute compatibility [telemetry-attribute-compatibility]
 
+```yaml {applies_to}
+product:
+  edot_ios: ga 2.1.0+
+```
+
 EDOT iOS emits current OpenTelemetry semantic-convention names by default.
 
 #### `useLegacyAttributeNames(_:)` [useLegacyAttributeNames]
@@ -198,7 +203,7 @@ EDOT iOS emits current OpenTelemetry semantic-convention names by default.
 | `Bool` | `false` |
 
 Restores the telemetry names emitted before the semantic-convention cleanup.
-Use this temporary compatibility option only while dashboards, alerts, or other
+Use this temporary compatibility option only until dashboards, alerts, or other
 consumers migrate to the current names:
 
 ```swift
@@ -208,7 +213,7 @@ let configuration = AgentConfigBuilder()
   .build()
 ```
 
-When enabled, this option restores all of the following legacy output:
+When enabled, this option restores the following legacy output:
 
 - URLSession spans use the old HTTP attributes such as `http.method`,
   `http.url`, and `http.status_code` instead of stable HTTP attributes.
@@ -222,12 +227,17 @@ When enabled, this option restores all of the following legacy output:
   `telemetry.sdk.version` uses the previous `semver:` prefix.
 
 The option changes only these compatibility names and the CPU value coupled to
-its metric name. It does not disable other fixes or instrumentation.
+its metric name. It does not turn off other fixes or instrumentation.
 
-#### Deprecated `ElasticAttributes` constants [deprecated-elastic-attributes]
+#### `ElasticAttributes` constants [deprecated-elastic-attributes]
 
-`ElasticAttributes` and all of its cases are deprecated in source after EDOT
-iOS 2.0.2. New integrations must use the upstream OpenTelemetry semantic
+```yaml {applies_to}
+product:
+  edot_ios: deprecated 2.1.0+
+```
+
+`ElasticAttributes` and all of its cases are deprecated in source in EDOT iOS
+2.1.0. New integrations must use the upstream OpenTelemetry semantic
 convention constants:
 
 - Replace `ElasticAttributes.deviceIdentifier` with


### PR DESCRIPTION
## Summary

Improves EDOT iOS SDK test confidence and aligns emitted telemetry with current semantic conventions while retaining an opt-in compatibility mode. SwiftPM and platform suites pass locally; hosted CI will validate the updated branch.

## Changes

- Add shared waiting exporters and exact resource and signal attribute assertions through the initialized pipeline.
- Use stable HTTP, lifecycle, crash, and process metric conventions by default.
- Add `useLegacyAttributeNames` to restore legacy telemetry names when needed.
- Preserve measured process memory values and normalize CPU utilization across available processors.
- Document the compatibility flag and deprecated attribute constants.