### PR TITLE
Add OTLP HTTP wire export tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -91,9 +91,19 @@ jobs:
         run: swift test
       - name: Build and test (iOS Simulator)
         if: ${{ matrix.label == 'ios' }}
+        env:
+          IOS_RESULT_BUNDLE_PATH: ${{ runner.temp }}/ios-tests.xcresult
         run: |
           make build-for-testing-ios
           make test-without-building-ios
+      - name: Upload failed iOS test results
+        if: ${{ failure() && matrix.label == 'ios' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ios-test-results
+          path: ${{ runner.temp }}/ios-tests.xcresult
+          if-no-files-found: warn
+          retention-days: 7
       - name: Build and test (tvOS Simulator)
         if: ${{ matrix.label == 'tvos' }}
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -96,12 +96,28 @@ jobs:
         run: |
           make build-for-testing-ios
           make test-without-building-ios
-      - name: Upload failed iOS test results
+      - name: Extract failed iOS test diagnostics
+        if: ${{ failure() && matrix.label == 'ios' }}
+        env:
+          IOS_RESULT_BUNDLE_PATH: ${{ runner.temp }}/ios-tests.xcresult
+          IOS_RESULT_DIAGNOSTICS_PATH: ${{ runner.temp }}/ios-test-diagnostics
+        run: |
+          if [[ ! -d "$IOS_RESULT_BUNDLE_PATH" ]]; then
+            echo "::warning::No iOS test result bundle was created"
+            exit 0
+          fi
+
+          mkdir -p "$IOS_RESULT_DIAGNOSTICS_PATH"
+          xcrun xcresulttool get test-results summary \
+            --path "$IOS_RESULT_BUNDLE_PATH" > "$IOS_RESULT_DIAGNOSTICS_PATH/summary.json"
+          xcrun xcresulttool get log --type action \
+            --path "$IOS_RESULT_BUNDLE_PATH" > "$IOS_RESULT_DIAGNOSTICS_PATH/action-log.json"
+      - name: Upload failed iOS test diagnostics
         if: ${{ failure() && matrix.label == 'ios' }}
         uses: actions/upload-artifact@v7
         with:
-          name: ios-test-results
-          path: ${{ runner.temp }}/ios-tests.xcresult
+          name: ios-test-diagnostics
+          path: ${{ runner.temp }}/ios-test-diagnostics
           if-no-files-found: warn
           retention-days: 7
       - name: Build and test (tvOS Simulator)

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ XCODEBUILD_OPTIONS_WATCHOS := \
 	-destination 'platform=watchOS Simulator,name=Apple Watch Series 11 (46mm)' \
 	-scheme $(PROJECT_NAME)
 
+XCODEBUILD_RESULT_BUNDLE_IOS := \
+	$(if $(IOS_RESULT_BUNDLE_PATH),-resultBundlePath '$(IOS_RESULT_BUNDLE_PATH)')
+
 .PHONY: setup-brew
 setup-brew:
 	brew update && brew install xcbeautify
@@ -39,7 +42,7 @@ build-for-testing-watchos:
 
 .PHONY: test-without-building-ios
 test-without-building-ios:
-	set -o pipefail && xcodebuild $(XCODEBUILD_OPTIONS_IOS) test-without-building | xcbeautify
+	set -o pipefail && xcodebuild $(XCODEBUILD_OPTIONS_IOS) $(XCODEBUILD_RESULT_BUNDLE_IOS) test-without-building | xcbeautify
 
 .PHONY: test-without-building-tvos
 test-without-building-tvos:

--- a/Sources/Tests/ElasticApmTestSupport/LoopbackHTTPTestServer.swift
+++ b/Sources/Tests/ElasticApmTestSupport/LoopbackHTTPTestServer.swift
@@ -15,6 +15,7 @@ import Foundation
 #if os(iOS) || os(macOS)
 
 public final class LoopbackHTTPTestServer {
+  private static let host = "127.0.0.1"
   private static let requestReadTimeout: TimeInterval = 10
 
   public struct Request: Equatable {
@@ -36,6 +37,13 @@ public final class LoopbackHTTPTestServer {
   }
 
   public private(set) var port = 0
+
+  public var baseURL: URL {
+    guard let url = URL(string: "http://\(Self.host):\(port)") else {
+      preconditionFailure("Failed to construct loopback server URL")
+    }
+    return url
+  }
 
   private let requestsQueue = DispatchQueue(label: "LoopbackHTTPTestServer.requests")
   private let serverQueue = DispatchQueue(label: "LoopbackHTTPTestServer.server")
@@ -77,7 +85,7 @@ public final class LoopbackHTTPTestServer {
     var address = sockaddr_in()
     address.sin_family = sa_family_t(AF_INET)
     address.sin_port = 0
-    address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+    address.sin_addr = in_addr(s_addr: UInt32(INADDR_LOOPBACK).bigEndian)
 
     let bindResult = withUnsafePointer(to: &address) { pointer in
       bind(
@@ -111,7 +119,7 @@ public final class LoopbackHTTPTestServer {
       throw ServerError.listenFailed
     }
 
-    recordEvent("listening on 127.0.0.1:\(port)")
+    recordEvent("listening on \(Self.host):\(port)")
     isRunning = true
     serverQueue.async { [weak self] in
       self?.acceptRequests()

--- a/Sources/Tests/ElasticApmTestSupport/LoopbackHTTPTestServer.swift
+++ b/Sources/Tests/ElasticApmTestSupport/LoopbackHTTPTestServer.swift
@@ -1,0 +1,299 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Adapted from opentelemetry-swift's Tests/Shared/TestUtils/HttpTestServer.swift.
+
+import Foundation
+
+#if canImport(Darwin)
+  import Darwin
+#elseif canImport(Glibc)
+  import Glibc
+#endif
+
+// EDOT currently supports iOS only; macOS retains the SwiftPM development loop.
+#if os(iOS) || os(macOS)
+
+public final class LoopbackHTTPTestServer {
+  public struct Request: Equatable {
+    public let method: String
+    public let path: String
+    public let headers: [String: String]
+
+    public func header(named name: String) -> String? {
+      headers.first { $0.key.caseInsensitiveCompare(name) == .orderedSame }?.value
+    }
+  }
+
+  public enum ServerError: Error {
+    case socketCreationFailed
+    case socketConfigurationFailed
+    case bindFailed
+    case portLookupFailed
+    case listenFailed
+  }
+
+  public private(set) var port = 0
+
+  private let requestsQueue = DispatchQueue(label: "LoopbackHTTPTestServer.requests")
+  private let serverQueue = DispatchQueue(label: "LoopbackHTTPTestServer.server")
+  private var recordedRequests: [Request] = []
+  private var recordedEvents: [String] = []
+  private var serverSocket: Int32 = -1
+  private var isRunning = false
+
+  public init() {}
+
+  public func start() throws {
+    #if canImport(Darwin)
+      serverSocket = socket(AF_INET, SOCK_STREAM, 0)
+    #else
+      serverSocket = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+    #endif
+    guard serverSocket >= 0 else {
+      throw ServerError.socketCreationFailed
+    }
+
+    var reuseAddress: Int32 = 1
+    guard setsockopt(
+      serverSocket,
+      SOL_SOCKET,
+      SO_REUSEADDR,
+      &reuseAddress,
+      socklen_t(MemoryLayout<Int32>.size)
+    ) == 0 else {
+      closeServerSocket()
+      throw ServerError.socketConfigurationFailed
+    }
+
+    let flags = fcntl(serverSocket, F_GETFL, 0)
+    guard flags >= 0, fcntl(serverSocket, F_SETFL, flags | O_NONBLOCK) == 0 else {
+      closeServerSocket()
+      throw ServerError.socketConfigurationFailed
+    }
+
+    var address = sockaddr_in()
+    address.sin_family = sa_family_t(AF_INET)
+    address.sin_port = 0
+    address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+    let bindResult = withUnsafePointer(to: &address) { pointer in
+      bind(
+        serverSocket,
+        UnsafeRawPointer(pointer).assumingMemoryBound(to: sockaddr.self),
+        socklen_t(MemoryLayout<sockaddr_in>.size)
+      )
+    }
+    guard bindResult == 0 else {
+      closeServerSocket()
+      throw ServerError.bindFailed
+    }
+
+    var boundAddress = sockaddr_in()
+    var boundAddressLength = socklen_t(MemoryLayout<sockaddr_in>.size)
+    let lookupResult = withUnsafeMutablePointer(to: &boundAddress) { pointer in
+      getsockname(
+        serverSocket,
+        UnsafeMutableRawPointer(pointer).assumingMemoryBound(to: sockaddr.self),
+        &boundAddressLength
+      )
+    }
+    guard lookupResult == 0 else {
+      closeServerSocket()
+      throw ServerError.portLookupFailed
+    }
+
+    port = Int(UInt16(bigEndian: boundAddress.sin_port))
+    guard listen(serverSocket, 16) == 0 else {
+      closeServerSocket()
+      throw ServerError.listenFailed
+    }
+
+    recordEvent("listening on 127.0.0.1:\(port)")
+    isRunning = true
+    serverQueue.async { [weak self] in
+      self?.acceptRequests()
+    }
+  }
+
+  public func stop() {
+    guard isRunning else {
+      return
+    }
+    isRunning = false
+    closeServerSocket()
+    serverQueue.sync {}
+  }
+
+  public var requests: [Request] {
+    requestsQueue.sync { recordedRequests }
+  }
+
+  public var diagnostics: String {
+    requestsQueue.sync {
+      let requestDescriptions = recordedRequests.enumerated().map { index, request in
+        let headers = ["Authorization", "Content-Type", "Content-Encoding", "Content-Length"]
+          .compactMap { name in
+            request.header(named: name).map { "\(name)=\($0)" }
+          }
+          .joined(separator: ", ")
+        return "[\(index)] \(request.method) \(request.path) {\(headers)}"
+      }
+      return """
+        Loopback server port: \(port)
+        Events: \(recordedEvents.isEmpty ? "none" : recordedEvents.joined(separator: " | "))
+        Requests: \(requestDescriptions.isEmpty ? "none" : requestDescriptions.joined(separator: " | "))
+        """
+    }
+  }
+
+  public func waitForRequest(
+    timeout: TimeInterval,
+    where predicate: (Request) -> Bool
+  ) -> Request? {
+    let deadline = Date().addingTimeInterval(timeout)
+    repeat {
+      if let request = requests.first(where: predicate) {
+        return request
+      }
+      Thread.sleep(forTimeInterval: 0.05)
+    } while Date() < deadline
+    return nil
+  }
+
+  deinit {
+    stop()
+  }
+
+  private func acceptRequests() {
+    while isRunning {
+      var clientAddress = sockaddr_in()
+      var clientAddressLength = socklen_t(MemoryLayout<sockaddr_in>.size)
+      let clientSocket = withUnsafeMutablePointer(to: &clientAddress) { pointer in
+        accept(
+          serverSocket,
+          UnsafeMutableRawPointer(pointer).assumingMemoryBound(to: sockaddr.self),
+          &clientAddressLength
+        )
+      }
+
+      guard clientSocket >= 0 else {
+        if isRunning, errno == EAGAIN || errno == EWOULDBLOCK {
+          Thread.sleep(forTimeInterval: 0.01)
+        } else if isRunning {
+          recordEvent("accept failed with errno \(errno)")
+        }
+        continue
+      }
+
+      recordEvent("accepted connection")
+      #if canImport(Darwin)
+        var noSignal: Int32 = 1
+        _ = setsockopt(
+          clientSocket,
+          SOL_SOCKET,
+          SO_NOSIGPIPE,
+          &noSignal,
+          socklen_t(MemoryLayout<Int32>.size)
+        )
+      #endif
+
+      handle(clientSocket)
+      close(clientSocket)
+    }
+  }
+
+  private func handle(_ clientSocket: Int32) {
+    var data = Data()
+    var buffer = [UInt8](repeating: 0, count: 4096)
+    let headerSeparator = Data("\r\n\r\n".utf8)
+
+    while data.range(of: headerSeparator) == nil {
+      let count = recv(clientSocket, &buffer, buffer.count, 0)
+      guard count > 0 else {
+        recordEvent("connection closed before complete headers; errno \(errno)")
+        sendResponse("HTTP/1.1 400 Bad Request", to: clientSocket)
+        return
+      }
+      data.append(contentsOf: buffer.prefix(count))
+    }
+
+    guard
+      let headerRange = data.range(of: headerSeparator),
+      let headerText = String(data: data[..<headerRange.lowerBound], encoding: .utf8)
+    else {
+      recordEvent("request headers were not valid UTF-8")
+      sendResponse("HTTP/1.1 400 Bad Request", to: clientSocket)
+      return
+    }
+
+    let lines = headerText.components(separatedBy: "\r\n")
+    let requestLine = lines[0].split(separator: " ")
+    guard requestLine.count >= 2 else {
+      recordEvent("request line was malformed: \(lines[0])")
+      sendResponse("HTTP/1.1 400 Bad Request", to: clientSocket)
+      return
+    }
+
+    var headers: [String: String] = [:]
+    for line in lines.dropFirst() {
+      guard let separator = line.firstIndex(of: ":") else {
+        continue
+      }
+      let name = line[..<separator].trimmingCharacters(in: .whitespaces)
+      let value = line[line.index(after: separator)...].trimmingCharacters(in: .whitespaces)
+      headers[name] = value
+    }
+
+    let contentLength = headers.first {
+      $0.key.caseInsensitiveCompare("Content-Length") == .orderedSame
+    }.flatMap { Int($0.value) } ?? 0
+    var receivedBodyBytes = data.count - headerRange.upperBound
+    while receivedBodyBytes < contentLength {
+      let count = recv(clientSocket, &buffer, min(buffer.count, contentLength - receivedBodyBytes), 0)
+      guard count > 0 else {
+        break
+      }
+      receivedBodyBytes += count
+    }
+
+    let request = Request(
+      method: String(requestLine[0]),
+      path: String(requestLine[1]),
+      headers: headers
+    )
+    requestsQueue.sync {
+      recordedRequests.append(request)
+      recordedEvents.append("recorded \(request.method) \(request.path)")
+    }
+    sendResponse("HTTP/1.1 200 OK", to: clientSocket)
+  }
+
+  private func recordEvent(_ event: String) {
+    requestsQueue.sync {
+      recordedEvents.append(event)
+    }
+  }
+
+  private func sendResponse(_ statusLine: String, to socket: Int32) {
+    let response = "\(statusLine)\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+    response.withCString { pointer in
+      _ = send(socket, pointer, strlen(pointer), 0)
+    }
+  }
+
+  private func closeServerSocket() {
+    guard serverSocket >= 0 else {
+      return
+    }
+    #if canImport(Darwin)
+      _ = Darwin.shutdown(serverSocket, SHUT_RDWR)
+    #elseif canImport(Glibc)
+      _ = Glibc.shutdown(serverSocket, Int32(SHUT_RDWR))
+    #endif
+    close(serverSocket)
+    serverSocket = -1
+  }
+}
+
+#endif

--- a/Sources/Tests/ElasticApmTestSupport/LoopbackHTTPTestServer.swift
+++ b/Sources/Tests/ElasticApmTestSupport/LoopbackHTTPTestServer.swift
@@ -15,6 +15,8 @@ import Foundation
 #if os(iOS) || os(macOS)
 
 public final class LoopbackHTTPTestServer {
+  private static let requestReadTimeout: TimeInterval = 10
+
   public struct Request: Equatable {
     public let method: String
     public let path: String
@@ -207,15 +209,22 @@ public final class LoopbackHTTPTestServer {
     var data = Data()
     var buffer = [UInt8](repeating: 0, count: 4096)
     let headerSeparator = Data("\r\n\r\n".utf8)
+    let readDeadline = Date().addingTimeInterval(Self.requestReadTimeout)
 
     while data.range(of: headerSeparator) == nil {
-      let count = recv(clientSocket, &buffer, buffer.count, 0)
-      guard count > 0 else {
-        recordEvent("connection closed before complete headers; errno \(errno)")
+      let result = receive(
+        from: clientSocket,
+        into: &buffer,
+        count: buffer.count,
+        deadline: readDeadline)
+      guard result.count > 0 else {
+        recordEvent(
+          result.error.map { "header receive failed with errno \($0)" }
+            ?? "connection closed before complete headers")
         sendResponse("HTTP/1.1 400 Bad Request", to: clientSocket)
         return
       }
-      data.append(contentsOf: buffer.prefix(count))
+      data.append(contentsOf: buffer.prefix(result.count))
     }
 
     guard
@@ -250,11 +259,19 @@ public final class LoopbackHTTPTestServer {
     }.flatMap { Int($0.value) } ?? 0
     var receivedBodyBytes = data.count - headerRange.upperBound
     while receivedBodyBytes < contentLength {
-      let count = recv(clientSocket, &buffer, min(buffer.count, contentLength - receivedBodyBytes), 0)
-      guard count > 0 else {
-        break
+      let result = receive(
+        from: clientSocket,
+        into: &buffer,
+        count: min(buffer.count, contentLength - receivedBodyBytes),
+        deadline: readDeadline)
+      guard result.count > 0 else {
+        recordEvent(
+          result.error.map { "body receive failed with errno \($0)" }
+            ?? "connection closed before complete body")
+        sendResponse("HTTP/1.1 400 Bad Request", to: clientSocket)
+        return
       }
-      receivedBodyBytes += count
+      receivedBodyBytes += result.count
     }
 
     let request = Request(
@@ -267,6 +284,33 @@ public final class LoopbackHTTPTestServer {
       recordedEvents.append("recorded \(request.method) \(request.path)")
     }
     sendResponse("HTTP/1.1 200 OK", to: clientSocket)
+  }
+
+  private func receive(
+    from socket: Int32,
+    into buffer: inout [UInt8],
+    count: Int,
+    deadline: Date
+  ) -> (count: Int, error: Int32?) {
+    while true {
+      let receivedCount = recv(socket, &buffer, count, 0)
+      guard receivedCount < 0 else {
+        return (receivedCount, nil)
+      }
+
+      let receiveError = errno
+      if receiveError == EINTR {
+        continue
+      }
+      if receiveError == EAGAIN || receiveError == EWOULDBLOCK {
+        guard Date() < deadline else {
+          return (receivedCount, receiveError)
+        }
+        Thread.sleep(forTimeInterval: 0.01)
+        continue
+      }
+      return (receivedCount, receiveError)
+    }
   }
 
   private func recordEvent(_ event: String) {

--- a/Sources/Tests/apm-agent-iosTests/OTLPHTTPWireTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/OTLPHTTPWireTests.swift
@@ -22,7 +22,58 @@
   import OpenTelemetrySdk
   import XCTest
 
+  #if canImport(Darwin)
+    import Darwin
+  #endif
+
   @testable import ElasticApm
+
+  final class LoopbackHTTPTestServerTests: XCTestCase {
+    func testWaitsForHeadersAfterAcceptingConnection() throws {
+      let server = LoopbackHTTPTestServer()
+      try server.start()
+      defer { server.stop() }
+
+      let clientSocket = socket(AF_INET, SOCK_STREAM, 0)
+      XCTAssertGreaterThanOrEqual(clientSocket, 0)
+      defer { close(clientSocket) }
+
+      var noSignal: Int32 = 1
+      XCTAssertEqual(
+        setsockopt(
+          clientSocket,
+          SOL_SOCKET,
+          SO_NOSIGPIPE,
+          &noSignal,
+          socklen_t(MemoryLayout<Int32>.size)),
+        0)
+
+      var address = sockaddr_in()
+      address.sin_family = sa_family_t(AF_INET)
+      address.sin_port = UInt16(server.port).bigEndian
+      address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+      let connectionResult = withUnsafePointer(to: &address) { pointer in
+        connect(
+          clientSocket,
+          UnsafeRawPointer(pointer).assumingMemoryBound(to: sockaddr.self),
+          socklen_t(MemoryLayout<sockaddr_in>.size))
+      }
+      XCTAssertEqual(connectionResult, 0)
+
+      Thread.sleep(forTimeInterval: 0.1)
+      let requestText = "POST /delayed HTTP/1.1\r\nContent-Length: 0\r\n\r\n"
+      let sentCount = requestText.withCString {
+        send(clientSocket, $0, strlen($0), 0)
+      }
+      XCTAssertEqual(sentCount, requestText.utf8.count)
+
+      let request = try XCTUnwrap(
+        server.waitForRequest(timeout: 2) { _ in true },
+        server.diagnostics)
+      XCTAssertEqual(request.method, "POST")
+      XCTAssertEqual(request.path, "/delayed")
+    }
+  }
 
   class OTLPHTTPWireTestCase: XCTestCase {
     static let requestTimeout: TimeInterval = 25

--- a/Sources/Tests/apm-agent-iosTests/OTLPHTTPWireTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/OTLPHTTPWireTests.swift
@@ -44,7 +44,7 @@
       try super.setUpWithError()
       XCTAssertNil(
         ProcessInfo.processInfo.environment["OTEL_EXPORTER_OTLP_HEADERS"],
-        "Wire tests require configured headers to reach the exporter")
+        "Wire tests require OTEL_EXPORTER_OTLP_HEADERS to be unset so the configured test authorization is used")
       try removePersistence()
     }
 

--- a/Sources/Tests/apm-agent-iosTests/OTLPHTTPWireTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/OTLPHTTPWireTests.swift
@@ -1,0 +1,387 @@
+// Copyright © 2026 Elasticsearch BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+// EDOT currently supports iOS only; macOS retains the SwiftPM development loop.
+#if os(iOS) || os(macOS)
+
+  import ElasticApmTestSupport
+  import Foundation
+  import NIO
+  import OpenTelemetryApi
+  import OpenTelemetrySdk
+  import XCTest
+
+  @testable import ElasticApm
+
+  class OTLPHTTPWireTestCase: XCTestCase {
+    static let requestTimeout: TimeInterval = 25
+    static let zeroRequestWindow: TimeInterval = 3
+
+    let fileManager = FileManager.default
+    var cachesDirectory: URL {
+      get throws {
+        try fileManager.url(
+          for: .cachesDirectory,
+          in: .userDomainMask,
+          appropriateFor: nil,
+          create: true
+        ).appendingPathComponent("elastic", isDirectory: true)
+      }
+    }
+
+    override func setUpWithError() throws {
+      try super.setUpWithError()
+      XCTAssertNil(
+        ProcessInfo.processInfo.environment["OTEL_EXPORTER_OTLP_HEADERS"],
+        "Wire tests require configured headers to reach the exporter")
+      try removePersistence()
+    }
+
+    override func tearDownWithError() throws {
+      try removePersistence()
+      try super.tearDownWithError()
+    }
+
+    func removePersistence() throws {
+      let directory = try cachesDirectory
+      if fileManager.fileExists(atPath: directory.path) {
+        try fileManager.removeItem(at: directory)
+      }
+    }
+
+    func assertNoPersistence(
+      file: StaticString = #filePath,
+      line: UInt = #line
+    ) throws {
+      let directory = try cachesDirectory
+      XCTAssertFalse(
+        fileManager.fileExists(atPath: directory.path),
+        "Agent startup created persistence directories: \(directoryDiagnostics(at: directory))",
+        file: file,
+        line: line)
+    }
+
+    func uniqueCredential(prefix: String = "wire") -> String {
+      "\(prefix)-\(UUID().uuidString)"
+    }
+
+    func matchingRequest(
+      on server: LoopbackHTTPTestServer,
+      authorization: String,
+      timeout: TimeInterval = requestTimeout
+    ) -> LoopbackHTTPTestServer.Request? {
+      server.waitForRequest(timeout: timeout) {
+        $0.header(named: "Authorization") == authorization
+      }
+    }
+  }
+
+  final class OTLPHTTPWireSignalTests: OTLPHTTPWireTestCase {
+    func testSpanExportsByPOSTToTracesPath() throws {
+      try withWirePipeline { harness in
+        harness.emitSpan()
+
+        let request = try XCTUnwrap(
+          harness.waitForRequest(),
+          harness.diagnostics)
+        XCTAssertEqual(request.method, "POST", harness.diagnostics)
+        XCTAssertEqual(request.path, "/v1/traces", harness.diagnostics)
+      }
+    }
+
+    func testLogExportsByPOSTToLogsPath() throws {
+      try withWirePipeline { harness in
+        harness.emitLog()
+
+        let request = try XCTUnwrap(
+          harness.waitForRequest(),
+          harness.diagnostics)
+        XCTAssertEqual(request.method, "POST", harness.diagnostics)
+        XCTAssertEqual(request.path, "/v1/logs", harness.diagnostics)
+      }
+    }
+
+    func testMetricExportsByPOSTToMetricsPath() throws {
+      try withWirePipeline { harness in
+        try harness.emitMetric()
+
+        let request = try XCTUnwrap(
+          harness.waitForRequest(),
+          harness.diagnostics)
+        XCTAssertEqual(request.method, "POST", harness.diagnostics)
+        XCTAssertEqual(request.path, "/v1/metrics", harness.diagnostics)
+      }
+    }
+  }
+
+  final class OTLPHTTPWireAuthenticationTests: OTLPHTTPWireTestCase {
+    func testSecretTokenExportsExactAuthorizationHeader() throws {
+      let token = uniqueCredential(prefix: "secret")
+      try withWirePipeline(authentication: .secretToken(token)) { harness in
+        harness.emitSpan()
+
+        let request = try XCTUnwrap(harness.waitForRequest(), harness.diagnostics)
+        XCTAssertEqual(request.header(named: "Authorization"), "Bearer \(token)")
+      }
+    }
+
+    func testAPIKeyExportsExactAuthorizationHeader() throws {
+      let key = uniqueCredential(prefix: "api-key")
+      try withWirePipeline(authentication: .apiKey(key)) { harness in
+        harness.emitSpan()
+
+        let request = try XCTUnwrap(harness.waitForRequest(), harness.diagnostics)
+        XCTAssertEqual(request.header(named: "Authorization"), "ApiKey \(key)")
+      }
+    }
+  }
+
+  final class OTLPHTTPWireEndpointTests: OTLPHTTPWireTestCase {
+    func testEndpointChangeRedirectsSubsequentRequests() throws {
+      let serverA = LoopbackHTTPTestServer()
+      let serverB = LoopbackHTTPTestServer()
+      try serverA.start()
+      try serverB.start()
+      defer {
+        serverA.stop()
+        serverB.stop()
+      }
+
+      let firstKey = uniqueCredential(prefix: "endpoint-a")
+      let first = try WireTelemetryHarness(server: serverA, authentication: .apiKey(firstKey))
+      first.emitSpan()
+      XCTAssertNotNil(first.waitForRequest(), first.diagnostics)
+      first.shutDown()
+
+      let secondKey = uniqueCredential(prefix: "endpoint-b")
+      let secondAuthorization = "ApiKey \(secondKey)"
+      let second = try WireTelemetryHarness(server: serverB, authentication: .apiKey(secondKey))
+      defer { second.shutDown() }
+      second.emitSpan()
+
+      XCTAssertNotNil(second.waitForRequest(), second.diagnostics)
+      XCTAssertNil(
+        matchingRequest(
+          on: serverA,
+          authorization: secondAuthorization,
+          timeout: Self.zeroRequestWindow),
+        serverA.diagnostics)
+    }
+  }
+
+  final class OTLPHTTPWireNoExportTests: OTLPHTTPWireTestCase {
+    func testDisabledAgentSendsNoRequestsAndCreatesNoPersistence() throws {
+      let server = LoopbackHTTPTestServer()
+      try server.start()
+      defer { server.stop() }
+
+      let configuration = AgentConfigBuilder()
+        .disableAgent()
+        .withExportUrl(URL(string: "http://127.0.0.1:\(server.port)")!)
+        .withApiKey(uniqueCredential())
+        .build()
+      ElasticApmAgent.start(with: configuration)
+
+      XCTAssertNil(
+        server.waitForRequest(timeout: Self.zeroRequestWindow) { _ in true },
+        server.diagnostics)
+      XCTAssertNil(ElasticApmAgent.shared())
+      try assertNoPersistence()
+    }
+
+    func testUnconfiguredAgentSendsNoRequestsAndCreatesNoPersistence() throws {
+      let server = LoopbackHTTPTestServer()
+      try server.start()
+      defer { server.stop() }
+
+      ElasticApmAgent.start(with: AgentConfigBuilder().build())
+
+      XCTAssertNil(
+        server.waitForRequest(timeout: Self.zeroRequestWindow) { _ in true },
+        server.diagnostics)
+      XCTAssertNil(ElasticApmAgent.shared())
+      try assertNoPersistence()
+    }
+  }
+
+  private enum WireAuthentication {
+    case apiKey(String)
+    case secretToken(String)
+
+    var headerValue: String {
+      switch self {
+      case .apiKey(let key):
+        return "ApiKey \(key)"
+      case .secretToken(let token):
+        return "Bearer \(token)"
+      }
+    }
+
+    func apply(to builder: AgentConfigBuilder) {
+      switch self {
+      case .apiKey(let key):
+        _ = builder.withApiKey(key)
+      case .secretToken(let token):
+        _ = builder.withSecretToken(token)
+      }
+    }
+  }
+
+  private final class WireTelemetryHarness {
+    let authorization: String
+
+    private let server: LoopbackHTTPTestServer
+    private let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    private let logExporter: LogRecordExporter
+    private let persistenceDirectory: URL
+
+    init(server: LoopbackHTTPTestServer, authentication: WireAuthentication) throws {
+      self.server = server
+      authorization = authentication.headerValue
+      persistenceDirectory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("edot-wire-\(UUID().uuidString)", isDirectory: true)
+
+      let builder = AgentConfigBuilder()
+        .withExportUrl(URL(string: "http://127.0.0.1:\(server.port)")!)
+        .withRemoteManagement(false)
+      authentication.apply(to: builder)
+      let configuration = builder.build()
+      let resource = AgentResource.get().merging(other: AgentEnvResource.get())
+      let configManager = AgentConfigManager(
+        resource: resource,
+        config: configuration,
+        instrumentationConfig: InstrumentationConfigBuilder()
+          .withPersistentStorageConfiguration(.instantDataDelivery)
+          .build())
+      let initializer = OpenTelemetryInitializer(
+        group: group,
+        sessionSampler: SessionSampler { 1.0 },
+        exporters: nil,
+        persistenceBaseDirectory: persistenceDirectory)
+
+      logExporter = initializer.initializeWithHttp(configManager)
+    }
+
+    func emitSpan() {
+      let tracer = OpenTelemetry.instance.tracerProvider.get(
+        instrumentationName: "OTLPHTTPWireTests")
+      tracer.spanBuilder(spanName: "wire-span").startSpan().end()
+    }
+
+    func emitLog() {
+      OpenTelemetry.instance.loggerProvider
+        .loggerBuilder(instrumentationScopeName: "OTLPHTTPWireTests")
+        .build()
+        .logRecordBuilder()
+        .setEventName("wire-log")
+        .emit()
+    }
+
+    func emitMetric() throws {
+      var counter = OpenTelemetry.instance.meterProvider
+        .get(name: "OTLPHTTPWireTests")
+        .counterBuilder(name: "wire.metric")
+        .build()
+      counter.add(value: 1)
+
+      let provider = try XCTUnwrap(
+        OpenTelemetry.instance.meterProvider as? MeterProviderSdk)
+      XCTAssertEqual(provider.forceFlush(), .success)
+    }
+
+    func waitForRequest() -> LoopbackHTTPTestServer.Request? {
+      server.waitForRequest(timeout: OTLPHTTPWireTestCase.requestTimeout) {
+        $0.header(named: "Authorization") == authorization
+      }
+    }
+
+    var diagnostics: String {
+      """
+      Expected authorization: \(authorization)
+      Providers: tracer=\(type(of: OpenTelemetry.instance.tracerProvider)), \
+      logger=\(type(of: OpenTelemetry.instance.loggerProvider)), \
+      meter=\(type(of: OpenTelemetry.instance.meterProvider))
+      \(server.diagnostics)
+      Persistence: \(directoryDiagnostics(at: persistenceDirectory))
+      """
+    }
+
+    func shutDown() {
+      if let tracerProvider = OpenTelemetry.instance.tracerProvider as? TracerProviderSdk {
+        tracerProvider.shutdown()
+      }
+      logExporter.shutdown()
+      if let meterProvider = OpenTelemetry.instance.meterProvider as? MeterProviderSdk {
+        XCTAssertEqual(meterProvider.shutdown(), .success)
+      }
+      XCTAssertNoThrow(try group.syncShutdownGracefully())
+      XCTAssertNoThrow(try FileManager.default.removeItem(at: persistenceDirectory))
+      XCTAssertFalse(FileManager.default.fileExists(atPath: persistenceDirectory.path))
+    }
+  }
+
+  private extension OTLPHTTPWireTestCase {
+    func withWirePipeline(
+      authentication: WireAuthentication? = nil,
+      _ test: (WireTelemetryHarness) throws -> Void
+    ) throws {
+      let server = LoopbackHTTPTestServer()
+      try server.start()
+      let selectedAuthentication = authentication
+        ?? .apiKey(uniqueCredential())
+      let harness = try WireTelemetryHarness(
+        server: server,
+        authentication: selectedAuthentication)
+      defer {
+        harness.shutDown()
+        server.stop()
+      }
+
+      try test(harness)
+    }
+  }
+
+  private func directoryDiagnostics(
+    at directory: URL,
+    fileManager: FileManager = .default
+  ) -> String {
+    guard fileManager.fileExists(atPath: directory.path) else {
+      return "\(directory.path) does not exist"
+    }
+
+    do {
+      let paths = try fileManager.subpathsOfDirectory(atPath: directory.path).sorted()
+      guard !paths.isEmpty else {
+        return "\(directory.path) is empty"
+      }
+      let entries = paths.map { path -> String in
+        let url = directory.appendingPathComponent(path)
+        do {
+          let attributes = try fileManager.attributesOfItem(atPath: url.path)
+          let size = (attributes[.size] as? NSNumber)?.intValue ?? 0
+          let age = (attributes[.modificationDate] as? Date)
+            .map { String(format: "%.1fs old", -$0.timeIntervalSinceNow) }
+            ?? "unknown age"
+          return "\(path) (\(size) bytes, \(age))"
+        } catch {
+          return "\(path) (attributes failed: \(error))"
+        }
+      }
+      return "\(directory.path): \(entries.joined(separator: " | "))"
+    } catch {
+      return "\(directory.path) inspection failed: \(error)"
+    }
+  }
+
+#endif

--- a/Sources/Tests/apm-agent-iosTests/OTLPHTTPWireTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/OTLPHTTPWireTests.swift
@@ -51,7 +51,7 @@
       var address = sockaddr_in()
       address.sin_family = sa_family_t(AF_INET)
       address.sin_port = UInt16(server.port).bigEndian
-      address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+      address.sin_addr = in_addr(s_addr: UInt32(INADDR_LOOPBACK).bigEndian)
       let connectionResult = withUnsafePointer(to: &address) { pointer in
         connect(
           clientSocket,
@@ -239,7 +239,7 @@
 
       let configuration = AgentConfigBuilder()
         .disableAgent()
-        .withExportUrl(URL(string: "http://127.0.0.1:\(server.port)")!)
+        .withExportUrl(server.baseURL)
         .withApiKey(uniqueCredential())
         .build()
       ElasticApmAgent.start(with: configuration)
@@ -304,7 +304,7 @@
         .appendingPathComponent("edot-wire-\(UUID().uuidString)", isDirectory: true)
 
       let builder = AgentConfigBuilder()
-        .withExportUrl(URL(string: "http://127.0.0.1:\(server.port)")!)
+        .withExportUrl(server.baseURL)
         .withRemoteManagement(false)
       authentication.apply(to: builder)
       let configuration = builder.build()

--- a/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
+++ b/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
@@ -42,6 +42,7 @@ class OpenTelemetryInitializer {
   let group: EventLoopGroup
   let sessionSampler: SessionSampler
   let exporters: Exporters?
+  let persistenceBaseDirectory: URL?
 
   static func createPersistenceFolder(
     for signal: PersistenceSignal,
@@ -120,11 +121,13 @@ class OpenTelemetryInitializer {
   init(
     group: EventLoopGroup,
     sessionSampler: SessionSampler,
-    exporters: Exporters? = nil
+    exporters: Exporters? = nil,
+    persistenceBaseDirectory: URL? = nil
   ) {
     self.group = group
     self.sessionSampler = sessionSampler
     self.exporters = exporters
+    self.persistenceBaseDirectory = persistenceBaseDirectory
   }
 
   // swiftlint:disable:next function_body_length
@@ -172,7 +175,10 @@ class OpenTelemetryInitializer {
       let defaultExporter = OtlpMetricExporter(
         channel: channel, config: otlpConfiguration, logger: Logger(label: Self.logLabel))
       do {
-        if let path = Self.createPersistenceFolder(for: .metrics) {
+        if let path = Self.createPersistenceFolder(
+          for: .metrics,
+          baseDirectory: persistenceBaseDirectory
+        ) {
           return try PersistenceMetricExporterDecorator(
             metricExporter: defaultExporter, storageURL: path, exportCondition: { true },
             performancePreset: configuration.instrumentation.storageConfiguration) as MetricExporter
@@ -185,7 +191,10 @@ class OpenTelemetryInitializer {
       let defaultExporter = OtlpTraceExporter(
         channel: channel, config: otlpConfiguration, logger: Logger(label: Self.logLabel))
       do {
-        if let path = Self.createPersistenceFolder(for: .traces) {
+        if let path = Self.createPersistenceFolder(
+          for: .traces,
+          baseDirectory: persistenceBaseDirectory
+        ) {
           return try PersistenceSpanExporterDecorator(
             spanExporter: OtlpTraceExporter(
               channel: channel, config: otlpConfiguration, logger: Logger(label: Self.logLabel)),
@@ -200,7 +209,10 @@ class OpenTelemetryInitializer {
       let defaultExporter = OtlpLogExporter(
         channel: channel, config: otlpConfiguration, logger: Logger(label: Self.logLabel))
       do {
-        if let path = Self.createPersistenceFolder(for: .logs) {
+        if let path = Self.createPersistenceFolder(
+          for: .logs,
+          baseDirectory: persistenceBaseDirectory
+        ) {
           return try PersistenceLogExporterDecorator(
             logRecordExporter: OtlpLogExporter(
               channel: channel, config: otlpConfiguration, logger: Logger(label: Self.logLabel)),
@@ -259,7 +271,10 @@ class OpenTelemetryInitializer {
       let metricEndpoint = URL(string: endpoint.absoluteString + "/v1/metrics")
       let defaultExporter = OtlpHttpMetricExporter(endpoint: metricEndpoint ?? endpoint, config: otlpConfiguration)
       do {
-        if let path = Self.createPersistenceFolder(for: .metrics) {
+        if let path = Self.createPersistenceFolder(
+          for: .metrics,
+          baseDirectory: persistenceBaseDirectory
+        ) {
           return try PersistenceMetricExporterDecorator(
             metricExporter: defaultExporter, storageURL: path, exportCondition: { true },
             performancePreset: configuration.instrumentation.storageConfiguration) as MetricExporter
@@ -273,7 +288,10 @@ class OpenTelemetryInitializer {
       let defaultExporter = OtlpHttpTraceExporter(
         endpoint: traceEndpoint ?? endpoint, config: otlpConfiguration)
       do {
-        if let path = Self.createPersistenceFolder(for: .traces) {
+        if let path = Self.createPersistenceFolder(
+          for: .traces,
+          baseDirectory: persistenceBaseDirectory
+        ) {
           return try PersistenceSpanExporterDecorator(
             spanExporter: defaultExporter,
             storageURL: path, exportCondition: { true },
@@ -287,7 +305,10 @@ class OpenTelemetryInitializer {
       let logsEndpoint = URL(string: endpoint.absoluteString + "/v1/logs")
       let defaultExporter = OtlpHttpLogExporter(endpoint: logsEndpoint ?? endpoint, config: otlpConfiguration)
       do {
-        if let path = Self.createPersistenceFolder(for: .logs) {
+        if let path = Self.createPersistenceFolder(
+          for: .logs,
+          baseDirectory: persistenceBaseDirectory
+        ) {
           return try PersistenceLogExporterDecorator(
             logRecordExporter: defaultExporter,
             storageURL: path, exportCondition: { true },


### PR DESCRIPTION
## Summary

Add wire-level coverage for real OTLP/HTTP exports. Local SwiftPM and simulator suites pass.

## Changes

- Add a dependency-free loopback HTTP test server with failure diagnostics and delayed-read handling.
- Verify trace, log, and metric paths plus both authentication forms.
- Verify endpoint changes and disabled or unconfigured no-export behavior.
- Isolate persistence storage per test pipeline and gate the suite to iOS and macOS.
- Retain compact iOS failure diagnostics for seven days.