### PR TITLE
test: add iOS end-to-end telemetry harness

### DIFF
--- a/.github/scripts/e2e-test/README.md
+++ b/.github/scripts/e2e-test/README.md
@@ -1,0 +1,43 @@
+# CI end-to-end test
+
+The end-to-end test runs the integration app in an iOS Simulator and confirms
+that its telemetry reaches Elasticsearch through an Elastic Agent OTLP
+endpoint.
+
+## What it validates
+
+The test:
+
+1. Starts Elasticsearch and the OTLP endpoint as native macOS processes.
+2. Builds the integration app in Release configuration with a dSYM.
+3. Installs and launches the app in a fresh iOS Simulator.
+4. Finds the app's span, log record, and metric in Elasticsearch.
+5. Verifies the service name, service version, and telemetry SDK name on each
+   matched document.
+
+Every query includes a unique `test.run_id` resource attribute. The harness
+passes that attribute at launch without adding test-only plumbing to the app.
+
+## Run locally
+
+The test requires macOS, Xcode with an iOS Simulator runtime, `curl`, `jq`,
+`nc`, `shasum`, and `tar`. No container runtime is required.
+
+Run this command from the repository root:
+
+```sh
+.github/scripts/e2e-test/e2e_test.sh
+```
+
+The first run downloads the pinned Elasticsearch and Elastic Agent archives to
+the ignored `.ci-cache/` directory. Set `ELASTIC_VERSION` to test another
+matching version.
+
+## Artifacts
+
+Results and diagnostics remain under `build/e2e/` after the run. They include:
+
+- Elasticsearch and OTLP endpoint logs.
+- App standard output, standard error, and Simulator logs on failure.
+- The query for each assertion.
+- The Elasticsearch document matched by each assertion.

--- a/.github/scripts/e2e-test/e2e_test.sh
+++ b/.github/scripts/e2e-test/e2e_test.sh
@@ -1,0 +1,435 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+REPO_ROOT=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)
+BUILD_DIR="$REPO_ROOT/build/e2e"
+CACHE_DIR="$REPO_ROOT/.ci-cache"
+RUNTIME_DIR="$BUILD_DIR/runtime"
+DERIVED_DATA_DIR="$BUILD_DIR/DerivedData"
+SOURCE_PACKAGES_DIR="$BUILD_DIR/SourcePackages"
+
+ELASTIC_VERSION=${ELASTIC_VERSION:-9.4.2}
+ELASTICSEARCH_URL=http://127.0.0.1:9200
+OTLP_HOST=127.0.0.1
+OTLP_HTTP_PORT=4318
+APP_SERVICE_NAME=integration-test-app
+APP_BUNDLE_ID=co.elastic.otel.ios.integration
+EXPECTED_SDK_NAME=iOS
+SIMULATOR_NAME_PREFIX="EDOT iOS SDK E2E"
+TEST_RUN_ID="ios-sdk-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-$(date +%s)"
+
+elasticsearch_pid=""
+collector_pid=""
+simulator_udid=""
+
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 ||
+    fail "Required command not found: $1"
+}
+
+wait_for_url() {
+  local url="$1"
+  local label="$2"
+  local timeout="${3:-120}"
+  local elapsed=0
+
+  until curl --fail --silent "$url" >/dev/null 2>&1; do
+    if [ "$elapsed" -ge "$timeout" ]; then
+      fail "Timed out waiting for $label at $url"
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+}
+
+wait_for_port() {
+  local host="$1"
+  local port="$2"
+  local label="$3"
+  local timeout="${4:-120}"
+  local elapsed=0
+
+  until nc -z "$host" "$port" >/dev/null 2>&1; do
+    if [ "$elapsed" -ge "$timeout" ]; then
+      fail "Timed out waiting for $label at $host:$port"
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+}
+
+download_archive() {
+  local url="$1"
+  local archive="$2"
+
+  if [ ! -f "$archive" ]; then
+    echo "Downloading $(basename "$archive")..."
+    curl --fail --location --retry 3 --retry-delay 2 \
+      --output "$archive" "$url"
+  fi
+
+  if [ ! -f "${archive}.sha512" ]; then
+    curl --fail --location --retry 3 --retry-delay 2 \
+      --output "${archive}.sha512" "${url}.sha512"
+  fi
+
+  local expected
+  expected=$(awk '{print $1}' "${archive}.sha512")
+  local actual
+  actual=$(shasum -a 512 "$archive" | awk '{print $1}')
+  if [ "$expected" != "$actual" ]; then
+    fail "SHA-512 checksum mismatch for $archive"
+  fi
+}
+
+service_filter() {
+  jq -nc \
+    --arg service "$APP_SERVICE_NAME" \
+    --arg run_id "$TEST_RUN_ID" \
+    '[
+      {
+        bool: {
+          should: [
+            {term: {"resource.attributes.service.name": $service}},
+            {term: {"service.name": $service}}
+          ],
+          minimum_should_match: 1
+        }
+      },
+      {
+        bool: {
+          should: [
+            {term: {"resource.attributes.test.run_id": $run_id}},
+            {term: {"test.run_id": $run_id}}
+          ],
+          minimum_should_match: 1
+        }
+      }
+    ]'
+}
+
+span_query() {
+  local filters
+  filters=$(service_filter)
+  jq -nc --argjson filters "$filters" '{
+    size: 1,
+    sort: [{"@timestamp": "desc"}],
+    query: {
+      bool: {
+        filter: ($filters + [{term: {name: "e2e span"}}])
+      }
+    }
+  }'
+}
+
+log_query() {
+  local filters
+  filters=$(service_filter)
+  jq -nc --argjson filters "$filters" '{
+    size: 1,
+    sort: [{"@timestamp": "desc"}],
+    query: {
+      bool: {
+        filter: ($filters + [{
+          bool: {
+            should: [
+              {match_phrase: {"body.text": "e2e log"}},
+              {match_phrase: {body: "e2e log"}},
+              {match_phrase: {message: "e2e log"}}
+            ],
+            minimum_should_match: 1
+          }
+        }])
+      }
+    }
+  }'
+}
+
+metric_query() {
+  local filters
+  filters=$(service_filter)
+  jq -nc --argjson filters "$filters" '{
+    size: 1,
+    sort: [{"@timestamp": "desc"}],
+    query: {
+      bool: {
+        filter: ($filters + [{
+          bool: {
+            should: [
+              {exists: {field: "metrics.e2e.launches"}},
+              {term: {"metric.name": "e2e.launches"}},
+              {term: {name: "e2e.launches"}}
+            ],
+            minimum_should_match: 1
+          }
+        }])
+      }
+    }
+  }'
+}
+
+es_search() {
+  local index="$1"
+  local query="$2"
+  local response
+
+  response=$(curl --fail --silent --show-error \
+    -H "Content-Type: application/json" \
+    --data "$query" \
+    "$ELASTICSEARCH_URL/$index/_search") || return 1
+
+  if [ "$(echo "$response" | jq -r '.hits.total.value // 0')" -lt 1 ]; then
+    return 1
+  fi
+  echo "$response" | jq -c '.hits.hits[0]'
+}
+
+es_wait_for_item() {
+  local index="$1"
+  local query="$2"
+  local label="$3"
+  local artifact_name="$4"
+  local timeout="${5:-180}"
+  local elapsed=0
+
+  echo "$query" | jq . > "$BUILD_DIR/${artifact_name}-query.json"
+  while [ "$elapsed" -lt "$timeout" ]; do
+    local result
+    if result=$(es_search "$index" "$query"); then
+      echo "$result" | jq . > "$BUILD_DIR/${artifact_name}.json"
+      echo "$result"
+      return 0
+    fi
+    echo "  ${elapsed}s/${timeout}s - waiting for $label..." >&2
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+
+  fail "Timed out after ${timeout}s waiting for $label"
+}
+
+document_attribute() {
+  local document="$1"
+  local attribute="$2"
+  echo "$document" | jq -r \
+    --arg attribute "$attribute" \
+    '._source.resource.attributes[$attribute] //
+     ._source[$attribute] //
+     empty'
+}
+
+assert_identity() {
+  local document="$1"
+  local label="$2"
+  local service_name
+  local service_version
+  local sdk_name
+
+  service_name=$(document_attribute "$document" "service.name")
+  service_version=$(document_attribute "$document" "service.version")
+  sdk_name=$(document_attribute "$document" "telemetry.sdk.name")
+
+  [ "$service_name" = "$APP_SERVICE_NAME" ] ||
+    fail "$label service.name: expected '$APP_SERVICE_NAME', got '$service_name'"
+  [ "$service_version" = "$APP_VERSION" ] ||
+    fail "$label service.version: expected '$APP_VERSION', got '$service_version'"
+  [ "$sdk_name" = "$EXPECTED_SDK_NAME" ] ||
+    fail "$label telemetry.sdk.name: expected '$EXPECTED_SDK_NAME', got '$sdk_name'"
+}
+
+print_failure_diagnostics() {
+  echo "=== E2E failure diagnostics ===" >&2
+  curl --silent "$ELASTICSEARCH_URL/_cluster/health?pretty" >&2 2>/dev/null || true
+
+  if [ -n "$simulator_udid" ]; then
+    xcrun simctl spawn "$simulator_udid" log show \
+      --style compact \
+      --last 10m \
+      --predicate 'process == "integration-test-app"' \
+      > "$BUILD_DIR/simulator-system.log" 2>&1 || true
+  fi
+
+  local file
+  for file in \
+    "$BUILD_DIR/elasticsearch.log" \
+    "$BUILD_DIR/otel-endpoint.log" \
+    "$BUILD_DIR/app.stdout.log" \
+    "$BUILD_DIR/app.stderr.log"; do
+    if [ -f "$file" ]; then
+      echo "--- Last 100 lines of $(basename "$file") ---" >&2
+      tail -n 100 "$file" >&2 || true
+    fi
+  done
+  echo "=== End E2E failure diagnostics ===" >&2
+}
+
+cleanup() {
+  local exit_code=$?
+  trap - EXIT
+
+  if [ "$exit_code" -ne 0 ]; then
+    print_failure_diagnostics
+  fi
+
+  if [ -n "$simulator_udid" ]; then
+    xcrun simctl shutdown "$simulator_udid" >/dev/null 2>&1 || true
+    xcrun simctl delete "$simulator_udid" >/dev/null 2>&1 || true
+  fi
+
+  local pid
+  for pid in "$collector_pid" "$elasticsearch_pid"; do
+    if [ -n "$pid" ]; then
+      kill "$pid" >/dev/null 2>&1 || true
+      wait "$pid" >/dev/null 2>&1 || true
+    fi
+  done
+
+  rm -rf "$RUNTIME_DIR" "$DERIVED_DATA_DIR" "$SOURCE_PACKAGES_DIR"
+  exit "$exit_code"
+}
+
+trap cleanup EXIT
+
+for command in awk curl git jq nc shasum tar xattr xcodebuild xcrun; do
+  require_command "$command"
+done
+[ -x /usr/libexec/PlistBuddy ] ||
+  fail "Required command not found: /usr/libexec/PlistBuddy"
+
+mkdir -p "$BUILD_DIR" "$CACHE_DIR"
+rm -rf "$RUNTIME_DIR" "$DERIVED_DATA_DIR" "$SOURCE_PACKAGES_DIR"
+mkdir -p "$RUNTIME_DIR"
+
+case "$(uname -m)" in
+  arm64) elastic_arch=aarch64 ;;
+  x86_64) elastic_arch=x86_64 ;;
+  *) fail "Unsupported macOS architecture: $(uname -m)" ;;
+esac
+
+elasticsearch_archive="$CACHE_DIR/elasticsearch-$ELASTIC_VERSION-darwin-$elastic_arch.tar.gz"
+collector_archive="$CACHE_DIR/elastic-agent-$ELASTIC_VERSION-darwin-$elastic_arch.tar.gz"
+
+download_archive \
+  "https://artifacts.elastic.co/downloads/elasticsearch/$(basename "$elasticsearch_archive")" \
+  "$elasticsearch_archive"
+download_archive \
+  "https://artifacts.elastic.co/downloads/beats/elastic-agent/$(basename "$collector_archive")" \
+  "$collector_archive"
+
+echo "Extracting Elastic distributions..."
+tar -xzf "$elasticsearch_archive" -C "$RUNTIME_DIR"
+tar -xzf "$collector_archive" -C "$RUNTIME_DIR"
+
+elasticsearch_home="$RUNTIME_DIR/elasticsearch-$ELASTIC_VERSION"
+collector_home="$RUNTIME_DIR/elastic-agent-$ELASTIC_VERSION-darwin-$elastic_arch"
+xattr -dr com.apple.quarantine "$elasticsearch_home" "$collector_home" 2>/dev/null || true
+
+echo "Starting Elasticsearch..."
+ES_JAVA_OPTS="-Xms512m -Xmx512m" \
+  "$elasticsearch_home/bin/elasticsearch" \
+  -Ediscovery.type=single-node \
+  -Expack.security.enabled=false \
+  -Expack.security.autoconfiguration.enabled=false \
+  -Expack.ml.enabled=false \
+  -Ecluster.routing.allocation.disk.threshold_enabled=false \
+  > "$BUILD_DIR/elasticsearch.log" 2>&1 &
+elasticsearch_pid=$!
+wait_for_url "$ELASTICSEARCH_URL" Elasticsearch 180
+
+echo "Starting Elastic Agent OTLP endpoint..."
+ELASTIC_ENDPOINT="$ELASTICSEARCH_URL" \
+  "$collector_home/otelcol" \
+  --config "$SCRIPT_DIR/otel.yml" \
+  > "$BUILD_DIR/otel-endpoint.log" 2>&1 &
+collector_pid=$!
+wait_for_port "$OTLP_HOST" "$OTLP_HTTP_PORT" "OTLP endpoint" 120
+
+echo "Creating iOS Simulator..."
+runtime_id=$(
+  xcrun simctl list runtimes -j |
+    jq -r '[.runtimes[] | select(.isAvailable == true and (.identifier | contains(".iOS-")))]
+      | sort_by(.version | split(".") | map(tonumber))
+      | last
+      | .identifier'
+)
+device_type_id=$(
+  xcrun simctl list devicetypes -j |
+    jq -r '[.devicetypes[] | select(.name | startswith("iPhone"))] | first | .identifier'
+)
+[ -n "$runtime_id" ] && [ "$runtime_id" != "null" ] ||
+  fail "No available iOS Simulator runtime found"
+[ -n "$device_type_id" ] && [ "$device_type_id" != "null" ] ||
+  fail "No iPhone Simulator device type found"
+
+simulator_udid=$(
+  xcrun simctl create \
+    "$SIMULATOR_NAME_PREFIX $TEST_RUN_ID" \
+    "$device_type_id" \
+    "$runtime_id"
+)
+xcrun simctl boot "$simulator_udid"
+xcrun simctl bootstatus "$simulator_udid" -b
+
+echo "Building and installing integration app..."
+xcodebuild -quiet \
+  -project "$REPO_ROOT/integration-test/IntegrationTestApp.xcodeproj" \
+  -scheme IntegrationTestApp \
+  -configuration Release \
+  -sdk iphonesimulator \
+  -destination "platform=iOS Simulator,id=$simulator_udid" \
+  -derivedDataPath "$DERIVED_DATA_DIR" \
+  -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+
+app_path="$DERIVED_DATA_DIR/Build/Products/Release-iphonesimulator/integration-test-app.app"
+dsym_path="${app_path}.dSYM"
+[ -d "$app_path" ] || fail "Release build did not produce $app_path"
+[ -d "$dsym_path" ] || fail "Release build did not produce $dsym_path"
+APP_VERSION=$(
+  /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$app_path/Info.plist"
+)
+[ -n "$APP_VERSION" ] || fail "Built app has no CFBundleShortVersionString"
+
+xcrun simctl install "$simulator_udid" "$app_path"
+: > "$BUILD_DIR/app.stdout.log"
+: > "$BUILD_DIR/app.stderr.log"
+
+echo "Launching integration app..."
+SIMCTL_CHILD_OTEL_RESOURCE_ATTRIBUTES="test.run_id=$TEST_RUN_ID" \
+  xcrun simctl launch \
+    --terminate-running-process \
+    --stdout="$BUILD_DIR/app.stdout.log" \
+    --stderr="$BUILD_DIR/app.stderr.log" \
+    "$simulator_udid" \
+    "$APP_BUNDLE_ID"
+
+span_document=$(es_wait_for_item \
+  "traces-*" \
+  "$(span_query)" \
+  "span named 'e2e span'" \
+  "span-document")
+assert_identity "$span_document" "Span document"
+
+log_document=$(es_wait_for_item \
+  "logs-*" \
+  "$(log_query)" \
+  "log record with body 'e2e log'" \
+  "log-document")
+assert_identity "$log_document" "Log document"
+
+metric_document=$(es_wait_for_item \
+  "metrics-*" \
+  "$(metric_query)" \
+  "metric named 'e2e.launches'" \
+  "metric-document")
+assert_identity "$metric_document" "Metric document"
+
+echo "E2E test succeeded for run ID $TEST_RUN_ID"

--- a/.github/scripts/e2e-test/otel.yml
+++ b/.github/scripts/e2e-test/otel.yml
@@ -1,0 +1,46 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 127.0.0.1:4317
+      http:
+        endpoint: 127.0.0.1:4318
+
+connectors:
+  elasticapm: {}
+
+processors:
+  batch:
+    send_batch_size: 1000
+    send_batch_max_size: 1500
+    timeout: 1s
+  batch/metrics:
+    send_batch_max_size: 0
+    timeout: 1s
+  elasticapm: {}
+
+exporters:
+  elasticsearch/otel:
+    endpoints:
+      - ${env:ELASTIC_ENDPOINT}
+    mapping:
+      mode: otel
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [elasticapm, elasticsearch/otel]
+    traces:
+      receivers: [otlp]
+      processors: [batch, elasticapm]
+      exporters: [elasticapm, elasticsearch/otel]
+    metrics:
+      receivers: [otlp]
+      processors: [batch/metrics]
+      exporters: [elasticsearch/otel]
+    metrics/aggregated-otel-metrics:
+      receivers: [elasticapm]
+      processors: []
+      exporters: [elasticsearch/otel]

--- a/.github/scripts/e2e-test/otel.yml
+++ b/.github/scripts/e2e-test/otel.yml
@@ -1,8 +1,6 @@
 receivers:
   otlp:
     protocols:
-      grpc:
-        endpoint: 127.0.0.1:4317
       http:
         endpoint: 127.0.0.1:4318
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,8 @@
 name: Build and Test
 
+env:
+  ELASTIC_VERSION: 9.4.2
+
 on:
   workflow_dispatch:
   pull_request:
@@ -11,39 +14,44 @@ permissions:
   contents: read
 
 jobs:
-  should-run:
+  changes:
     runs-on: ubuntu-slim
     outputs:
-      should-run: ${{ steps.check.outputs.should-run }}
+      code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - name: Check if the workflow should run
-        id: check
+      - id: filter
+        name: Detect non-Markdown changes
+        shell: bash
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+          PUSH_HEAD_SHA: ${{ github.sha }}
         run: |
-          SHOULD_RUN=false
-
-          # github.base_ref is empty for push and workflow_dispatch; run all jobs.
-          if [ -z "${{ github.base_ref }}" ]; then
-            SHOULD_RUN=true
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            base_sha="$PR_BASE_SHA"
+            head_sha="$PR_HEAD_SHA"
           else
-            CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }} HEAD)
-
-            echo "$CHANGED_FILES" | grep -qE '^Sources/|^\.ci/' && SHOULD_RUN=true
-
-            if echo "$CHANGED_FILES" | grep -q '^Package\.swift$'; then
-              git diff origin/${{ github.base_ref }} HEAD -- Package.swift | grep -q . && SHOULD_RUN=true
-            fi
-
-            echo "$CHANGED_FILES" | grep -qE '^\.github/workflows/' && SHOULD_RUN=true
+            base_sha="$PUSH_BASE_SHA"
+            head_sha="$PUSH_HEAD_SHA"
           fi
 
-          echo "should-run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+          if [[ -z "$base_sha" || "$base_sha" =~ ^0+$ ]] || \
+             ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+            echo "Unable to compare with the previous revision; running code checks."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          elif git diff --quiet "$base_sha" "$head_sha" -- . ':(exclude,glob)**/*.md'; then
+            echo "Only Markdown files changed; skipping code checks."
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Non-Markdown files changed; running code checks."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          fi
 
   swift-lint:
-    needs: should-run
-    if: ${{ needs.should-run.outputs.should-run == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -55,8 +63,8 @@ jobs:
           DIFF_BASE: ${{ github.base_ref || github.event.repository.default_branch }}
   xcode-matrix:
     name: xcode (${{ matrix.label }})
-    needs: should-run
-    if: ${{ needs.should-run.outputs.should-run == 'true' }}
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -134,10 +142,37 @@ jobs:
         if: ${{ matrix.label == 'iphoneos-build' }}
         run: .ci/scripts/build.sh
 
+  e2e:
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
+    runs-on: macos-latest-large
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          xcode-version: latest-stable
+      - name: Cache Elastic distributions
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .ci-cache
+          key: elastic-e2e-${{ env.ELASTIC_VERSION }}-${{ runner.os }}-${{ runner.arch }}
+      - name: Run end-to-end telemetry test
+        run: .github/scripts/e2e-test/e2e_test.sh
+      - name: Store end-to-end diagnostics
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: e2e-results
+          path: build/e2e/*
+          if-no-files-found: error
+
   required-status-checks:
     needs:
+      - changes
       - swift-lint
       - xcode-matrix
+      - e2e
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -150,8 +185,8 @@ jobs:
       - run: ${{ steps.check.outputs.is-success }}
 
   package:
-    needs: [should-run, required-status-checks]
-    if: ${{ needs.should-run.outputs.should-run == 'true' && needs.required-status-checks.result == 'success' }}
+    needs: [changes, required-status-checks]
+    if: ${{ needs.changes.outputs.code == 'true' && needs.required-status-checks.result == 'success' }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ playground.xcworkspace
 # .swiftpm
 
 .build/
+.ci-cache/
 
 # CocoaPods
 #

--- a/integration-test/IntegrationTestApp.xcodeproj/project.pbxproj
+++ b/integration-test/IntegrationTestApp.xcodeproj/project.pbxproj
@@ -1,0 +1,377 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0DA42B98186D4A3C04C2010F /* IntegrationTestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8287A8FC635A1EDD9009488A /* IntegrationTestApp.swift */; };
+		1E2442B4EB64F939A612BC05 /* IntegrationHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB247F5064034107BB47FA8B /* IntegrationHomeView.swift */; };
+		259D0F61A07672C9133727D6 /* IntegrationTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5C7BC1D901420C40049E05 /* IntegrationTelemetry.swift */; };
+		5FCE11860A0BD7C5B0036B46 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0E82BC29BF788936C46ACED6 /* Assets.xcassets */; };
+		8BC4DF3693D7662ED0FB1388 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08A78264121965808EB4E8D0 /* Foundation.framework */; };
+		BF0590504BF63D1FAC8775F2 /* ElasticApm in Frameworks */ = {isa = PBXBuildFile; productRef = A8C6B9D7DA5F170A86F58C05 /* ElasticApm */; };
+		C42D24A403525C8D1D2573ED /* OpenTelemetryApi in Frameworks */ = {isa = PBXBuildFile; productRef = 336F1C931CDB75BD6EF54538 /* OpenTelemetryApi */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		08A78264121965808EB4E8D0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		0D5C7BC1D901420C40049E05 /* IntegrationTelemetry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntegrationTelemetry.swift; sourceTree = "<group>"; };
+		0E82BC29BF788936C46ACED6 /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		8287A8FC635A1EDD9009488A /* IntegrationTestApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntegrationTestApp.swift; sourceTree = "<group>"; };
+		A9798CD10E9571AE1EBF6C75 /* IntegrationTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IntegrationTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		BB247F5064034107BB47FA8B /* IntegrationHomeView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntegrationHomeView.swift; sourceTree = "<group>"; };
+		BC21FDD28720AF02A26EFC49 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		F5444C2D99BE621A73D49137 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8BC4DF3693D7662ED0FB1388 /* Foundation.framework in Frameworks */,
+				BF0590504BF63D1FAC8775F2 /* ElasticApm in Frameworks */,
+				C42D24A403525C8D1D2573ED /* OpenTelemetryApi in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		13219D29AC60AA5365E6855B /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				08A78264121965808EB4E8D0 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		7C2CC880416966788AF71439 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				13219D29AC60AA5365E6855B /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		9DDDE0822E4303B030DAA2CF /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A9798CD10E9571AE1EBF6C75 /* IntegrationTestApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		C20C094A159B3BE21668FA68 = {
+			isa = PBXGroup;
+			children = (
+				9DDDE0822E4303B030DAA2CF /* Products */,
+				7C2CC880416966788AF71439 /* Frameworks */,
+				FA8147346FE37BD3226CC8C4 /* IntegrationTestApp */,
+			);
+			sourceTree = "<group>";
+		};
+		FA8147346FE37BD3226CC8C4 /* IntegrationTestApp */ = {
+			isa = PBXGroup;
+			children = (
+				8287A8FC635A1EDD9009488A /* IntegrationTestApp.swift */,
+				0D5C7BC1D901420C40049E05 /* IntegrationTelemetry.swift */,
+				BB247F5064034107BB47FA8B /* IntegrationHomeView.swift */,
+				BC21FDD28720AF02A26EFC49 /* Info.plist */,
+				0E82BC29BF788936C46ACED6 /* Assets.xcassets */,
+			);
+			name = IntegrationTestApp;
+			path = IntegrationTestApp;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		CF4E30B7583EF0E665B19593 /* IntegrationTestApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BC702CC7C21E177457311E92 /* Build configuration list for PBXNativeTarget "IntegrationTestApp" */;
+			buildPhases = (
+				3CC0E356CFA6F718CBC1A69A /* Sources */,
+				F5444C2D99BE621A73D49137 /* Frameworks */,
+				DFF4BE6AE311572186D4A03C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = IntegrationTestApp;
+			packageProductDependencies = (
+				A8C6B9D7DA5F170A86F58C05 /* ElasticApm */,
+				336F1C931CDB75BD6EF54538 /* OpenTelemetryApi */,
+			);
+			productName = IntegrationTestApp;
+			productReference = A9798CD10E9571AE1EBF6C75 /* IntegrationTestApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		19E281319BD0FF65D64FA2B0 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2660;
+				LastUpgradeCheck = 2660;
+			};
+			buildConfigurationList = 14206308B4376433FE5A449C /* Build configuration list for PBXProject "IntegrationTestApp" */;
+			compatibilityVersion = "Xcode 15.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = C20C094A159B3BE21668FA68;
+			minimizedProjectReferenceProxies = 0;
+			packageReferences = (
+				49F6FAAD068ED83C21A15D92 /* XCLocalSwiftPackageReference ".." */,
+			);
+			preferredProjectObjectVersion = 100;
+			productRefGroup = 9DDDE0822E4303B030DAA2CF /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CF4E30B7583EF0E665B19593 /* IntegrationTestApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		DFF4BE6AE311572186D4A03C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5FCE11860A0BD7C5B0036B46 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3CC0E356CFA6F718CBC1A69A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0DA42B98186D4A3C04C2010F /* IntegrationTestApp.swift in Sources */,
+				259D0F61A07672C9133727D6 /* IntegrationTelemetry.swift in Sources */,
+				1E2442B4EB64F939A612BC05 /* IntegrationHomeView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		6C8D40EBB1A1553CE1886083 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = IntegrationTestApp/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = co.elastic.otel.ios.integration;
+				PRODUCT_NAME = "integration-test-app";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		728F1DAAF13F5A0F5D2FB296 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		F714AF506E18F1EC93E64714 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		F7466357AD35950EA774DB24 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = IntegrationTestApp/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = co.elastic.otel.ios.integration;
+				PRODUCT_NAME = "integration-test-app";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		14206308B4376433FE5A449C /* Build configuration list for PBXProject "IntegrationTestApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				728F1DAAF13F5A0F5D2FB296 /* Debug */,
+				F714AF506E18F1EC93E64714 /* Release */,
+			);
+			defaultConfigurationName = Release;
+		};
+		BC702CC7C21E177457311E92 /* Build configuration list for PBXNativeTarget "IntegrationTestApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6C8D40EBB1A1553CE1886083 /* Release */,
+				F7466357AD35950EA774DB24 /* Debug */,
+			);
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		49F6FAAD068ED83C21A15D92 /* XCLocalSwiftPackageReference ".." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ..;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		336F1C931CDB75BD6EF54538 /* OpenTelemetryApi */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 49F6FAAD068ED83C21A15D92 /* XCLocalSwiftPackageReference ".." */;
+			productName = OpenTelemetryApi;
+		};
+		A8C6B9D7DA5F170A86F58C05 /* ElasticApm */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 49F6FAAD068ED83C21A15D92 /* XCLocalSwiftPackageReference ".." */;
+			productName = ElasticApm;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 19E281319BD0FF65D64FA2B0 /* Project object */;
+}

--- a/integration-test/IntegrationTestApp.xcodeproj/project.pbxproj
+++ b/integration-test/IntegrationTestApp.xcodeproj/project.pbxproj
@@ -11,13 +11,11 @@
 		1E2442B4EB64F939A612BC05 /* IntegrationHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB247F5064034107BB47FA8B /* IntegrationHomeView.swift */; };
 		259D0F61A07672C9133727D6 /* IntegrationTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5C7BC1D901420C40049E05 /* IntegrationTelemetry.swift */; };
 		5FCE11860A0BD7C5B0036B46 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0E82BC29BF788936C46ACED6 /* Assets.xcassets */; };
-		8BC4DF3693D7662ED0FB1388 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08A78264121965808EB4E8D0 /* Foundation.framework */; };
 		BF0590504BF63D1FAC8775F2 /* ElasticApm in Frameworks */ = {isa = PBXBuildFile; productRef = A8C6B9D7DA5F170A86F58C05 /* ElasticApm */; };
 		C42D24A403525C8D1D2573ED /* OpenTelemetryApi in Frameworks */ = {isa = PBXBuildFile; productRef = 336F1C931CDB75BD6EF54538 /* OpenTelemetryApi */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		08A78264121965808EB4E8D0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		0D5C7BC1D901420C40049E05 /* IntegrationTelemetry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntegrationTelemetry.swift; sourceTree = "<group>"; };
 		0E82BC29BF788936C46ACED6 /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8287A8FC635A1EDD9009488A /* IntegrationTestApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntegrationTestApp.swift; sourceTree = "<group>"; };
@@ -31,7 +29,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8BC4DF3693D7662ED0FB1388 /* Foundation.framework in Frameworks */,
 				BF0590504BF63D1FAC8775F2 /* ElasticApm in Frameworks */,
 				C42D24A403525C8D1D2573ED /* OpenTelemetryApi in Frameworks */,
 			);
@@ -40,22 +37,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		13219D29AC60AA5365E6855B /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				08A78264121965808EB4E8D0 /* Foundation.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		7C2CC880416966788AF71439 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				13219D29AC60AA5365E6855B /* iOS */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		9DDDE0822E4303B030DAA2CF /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -68,7 +49,6 @@
 			isa = PBXGroup;
 			children = (
 				9DDDE0822E4303B030DAA2CF /* Products */,
-				7C2CC880416966788AF71439 /* Frameworks */,
 				FA8147346FE37BD3226CC8C4 /* IntegrationTestApp */,
 			);
 			sourceTree = "<group>";

--- a/integration-test/IntegrationTestApp.xcodeproj/xcshareddata/xcschemes/IntegrationTestApp.xcscheme
+++ b/integration-test/IntegrationTestApp.xcodeproj/xcshareddata/xcschemes/IntegrationTestApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CF4E30B7583EF0E665B19593"
+               BuildableName = "integration-test-app.app"
+               BlueprintName = "IntegrationTestApp"
+               ReferencedContainer = "container:IntegrationTestApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CF4E30B7583EF0E665B19593"
+            BuildableName = "integration-test-app.app"
+            BlueprintName = "IntegrationTestApp"
+            ReferencedContainer = "container:IntegrationTestApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CF4E30B7583EF0E665B19593"
+            BuildableName = "integration-test-app.app"
+            BlueprintName = "IntegrationTestApp"
+            ReferencedContainer = "container:IntegrationTestApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/integration-test/IntegrationTestApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/integration-test/IntegrationTestApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/integration-test/IntegrationTestApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/integration-test/IntegrationTestApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/integration-test/IntegrationTestApp/Assets.xcassets/Contents.json
+++ b/integration-test/IntegrationTestApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/integration-test/IntegrationTestApp/Info.plist
+++ b/integration-test/IntegrationTestApp/Info.plist
@@ -24,7 +24,7 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsArbitraryLoads</key>
+		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
 	<key>UIApplicationSceneManifest</key>

--- a/integration-test/IntegrationTestApp/Info.plist
+++ b/integration-test/IntegrationTestApp/Info.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>EDOT iOS Integration Test</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/integration-test/IntegrationTestApp/IntegrationHomeView.swift
+++ b/integration-test/IntegrationTestApp/IntegrationHomeView.swift
@@ -1,0 +1,27 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ */
+
+import SwiftUI
+
+/// The app's single screen. It carries no test-only state; the app emits its telemetry from
+/// `AppDelegate.application(_:didFinishLaunchingWithOptions:)` before this view ever renders.
+struct IntegrationHomeView: View {
+  var body: some View {
+    VStack(spacing: 12) {
+      Image(systemName: "checkmark.seal")
+        .font(.system(size: 48))
+      Text("EDOT iOS Integration Test")
+        .font(.headline)
+      Text("This app exists only to exercise the SDK's export path for the E2E harness.")
+        .font(.footnote)
+        .multilineTextAlignment(.center)
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 32)
+    }
+    .padding()
+  }
+}

--- a/integration-test/IntegrationTestApp/IntegrationTelemetry.swift
+++ b/integration-test/IntegrationTestApp/IntegrationTelemetry.swift
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ */
+
+import Foundation
+import OpenTelemetryApi
+
+/// Emits the exactly-once span, log, and metric that the E2E harness asserts in Elasticsearch.
+/// There is no scenario hook and no run-id reader: the harness carries `test.run_id` through
+/// `SIMCTL_CHILD_OTEL_RESOURCE_ATTRIBUTES`, and the agent picks it up from the process
+/// environment on its own.
+enum IntegrationTelemetry {
+  private static let instrumentationScope = "co.elastic.otel.ios.integration"
+
+  static func emitLaunchSignals() {
+    emitSpan()
+    emitLog()
+    emitMetric()
+  }
+
+  private static func emitSpan() {
+    let tracer = OpenTelemetry.instance.tracerProvider.get(
+      instrumentationName: instrumentationScope)
+    tracer.spanBuilder(spanName: "e2e span").startSpan().end()
+  }
+
+  private static func emitLog() {
+    OpenTelemetry.instance.loggerProvider
+      .loggerBuilder(instrumentationScopeName: instrumentationScope)
+      .build()
+      .logRecordBuilder()
+      .setBody(.string("e2e log"))
+      .emit()
+  }
+
+  private static func emitMetric() {
+    var counter = OpenTelemetry.instance.meterProvider
+      .get(name: instrumentationScope)
+      .counterBuilder(name: "e2e.launches")
+      .build()
+    counter.add(value: 1)
+  }
+}

--- a/integration-test/IntegrationTestApp/IntegrationTestApp.swift
+++ b/integration-test/IntegrationTestApp/IntegrationTestApp.swift
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ */
+
+import ElasticApm
+import OpenTelemetryApi
+import SwiftUI
+import UIKit
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    // The harness (`.github/scripts/e2e-test/e2e_test.sh`) runs the Elastic Agent OTLP endpoint
+    // on the simulator host's loopback address.
+    let agentConfiguration = AgentConfigBuilder()
+      .withExportUrl(URL(string: "http://127.0.0.1:4318")!)
+      .withRemoteManagement(false)
+      .build()
+
+    ElasticApmAgent.start(with: agentConfiguration)
+    IntegrationTelemetry.emitLaunchSignals()
+
+    return true
+  }
+}
+
+@main
+struct IntegrationTestApp: App {
+  @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
+  var body: some Scene {
+    WindowGroup {
+      IntegrationHomeView()
+    }
+  }
+}

--- a/integration-test/IntegrationTestApp/IntegrationTestApp.swift
+++ b/integration-test/IntegrationTestApp/IntegrationTestApp.swift
@@ -6,7 +6,6 @@
  */
 
 import ElasticApm
-import OpenTelemetryApi
 import SwiftUI
 import UIKit
 


### PR DESCRIPTION
## Summary

Adds end-to-end coverage for iOS telemetry export and verifies the harness locally against Elasticsearch.

## Changes

- Add a purpose-built iOS integration app that emits a span, log, and metric.
- Add a native macOS harness that validates ingested telemetry and preserves diagnostics.
- Add the E2E job and replace source-path filtering with a docs-only CI skip.