### PR TITLE
Prefer delta aggregation temporality for metrics

### DIFF
--- a/Sources/Tests/ElasticApmTestSupport/WaitingExporters.swift
+++ b/Sources/Tests/ElasticApmTestSupport/WaitingExporters.swift
@@ -109,10 +109,16 @@ public final class WaitingMetricExporter: MetricExporter {
   private var metricDataList = [MetricData]()
   private let condition = NSCondition()
   private let numberToWaitFor: Int
+  private let aggregationTemporalitySelector: AggregationTemporalitySelector
   public private(set) var shutdownCalled = false
 
-  public init(numberToWaitFor: Int) {
+  public init(
+    numberToWaitFor: Int,
+    aggregationTemporalitySelector: AggregationTemporalitySelector =
+      AggregationTemporality.deltaPreferred()
+  ) {
     self.numberToWaitFor = numberToWaitFor
+    self.aggregationTemporalitySelector = aggregationTemporalitySelector
   }
 
   public func waitForExport(timeout: TimeInterval = 10) -> [MetricData]? {
@@ -150,6 +156,6 @@ public final class WaitingMetricExporter: MetricExporter {
   public func getAggregationTemporality(
     for instrument: InstrumentType
   ) -> AggregationTemporality {
-    .cumulative
+    aggregationTemporalitySelector.getAggregationTemporality(for: instrument)
   }
 }

--- a/Sources/Tests/apm-agent-iosTests/MetricTemporalityTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/MetricTemporalityTests.swift
@@ -1,0 +1,173 @@
+// Copyright © 2026 Elasticsearch BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+import ElasticApmTestSupport
+import Foundation
+import NIO
+import OpenTelemetryApi
+import OpenTelemetryProtocolExporterCommon
+import OpenTelemetrySdk
+import PersistenceExporter
+import XCTest
+
+@testable import ElasticApm
+
+final class MetricTemporalityTests: XCTestCase {
+  func testGrpcExporterProducesDeltaPreferredMetricData() throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    let channel = OpenTelemetryHelper.makeChannel(
+      target: try XCTUnwrap(GrpcChannelTarget(endpoint: URL(string: "http://localhost:4317")!)),
+      group: group)
+    let exporter = OpenTelemetryInitializer.makeGrpcMetricExporter(
+      channel: channel, config: OtlpConfiguration())
+    defer {
+      XCTAssertEqual(exporter.shutdown(), .success)
+      XCTAssertNoThrow(try group.syncShutdownGracefully())
+    }
+
+    try assertExportedMetricTemporalities(from: exporter)
+  }
+
+  func testHttpExporterProducesDeltaPreferredMetricData() throws {
+    let exporter = OpenTelemetryInitializer.makeHttpMetricExporter(
+      endpoint: URL(string: "http://localhost:4318/v1/metrics")!,
+      config: OtlpConfiguration())
+    defer {
+      XCTAssertEqual(exporter.shutdown(), .success)
+    }
+
+    try assertExportedMetricTemporalities(from: exporter)
+  }
+
+  func testPersistenceDecoratorPreservesDeltaPreferredTemporality() throws {
+    let storageURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("metric-temporality-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: storageURL, withIntermediateDirectories: true)
+    defer {
+      XCTAssertNoThrow(try FileManager.default.removeItem(at: storageURL))
+    }
+
+    let exporter = OpenTelemetryInitializer.makeHttpMetricExporter(
+      endpoint: URL(string: "http://localhost:4318/v1/metrics")!,
+      config: OtlpConfiguration())
+    let decoratedExporter = try PersistenceMetricExporterDecorator(
+      metricExporter: exporter,
+      storageURL: storageURL,
+      exportCondition: { false })
+    defer {
+      XCTAssertEqual(decoratedExporter.shutdown(), .success)
+    }
+
+    assertDeltaPreferredMapping(on: decoratedExporter)
+  }
+
+  private func assertExportedMetricTemporalities(
+    from exporter: MetricExporter,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) throws {
+    let collectingExporter = WaitingMetricExporter(
+      numberToWaitFor: 1,
+      aggregationTemporalitySelector: AggregationTemporalitySelector {
+        exporter.getAggregationTemporality(for: $0)
+      })
+    let provider = MeterProviderSdk.builder()
+      .registerView(
+        selector: InstrumentSelector.builder()
+          .setInstrument(name: ".*")
+          .build(),
+        view: View.builder().build()
+      )
+      .registerMetricReader(
+        reader: PeriodicMetricReaderBuilder(exporter: collectingExporter).build()
+      )
+      .build()
+    let meter = provider.get(name: "MetricTemporalityTests")
+
+    let counter = meter.counterBuilder(name: "temporality.counter").build()
+    counter.add(value: 1)
+
+    let observableCounter = meter.counterBuilder(name: "temporality.observable-counter")
+      .buildWithCallback { measurement in
+        measurement.record(value: 2)
+      }
+
+    let histogram = meter.histogramBuilder(name: "temporality.histogram").build()
+    histogram.record(value: 3)
+
+    let upDownCounter = meter.upDownCounterBuilder(name: "temporality.up-down-counter").build()
+    upDownCounter.add(value: 4)
+
+    let observableUpDownCounter = meter
+      .upDownCounterBuilder(name: "temporality.observable-up-down-counter")
+      .buildWithCallback { measurement in
+        measurement.record(value: 5)
+      }
+
+    let exportedMetrics = try withExtendedLifetime(observableCounter) {
+      try withExtendedLifetime(observableUpDownCounter) {
+        XCTAssertEqual(provider.forceFlush(), .success, file: file, line: line)
+        return try XCTUnwrap(
+          collectingExporter.waitForExport(),
+          "Expected all instrument types to be exported",
+          file: file,
+          line: line)
+      }
+    }
+    XCTAssertEqual(provider.shutdown(), .success, file: file, line: line)
+
+    let temporalities = Dictionary(
+      uniqueKeysWithValues: exportedMetrics.map {
+        ($0.name, $0.data.aggregationTemporality)
+      })
+    XCTAssertEqual(temporalities["temporality.counter"], .delta, file: file, line: line)
+    XCTAssertEqual(
+      temporalities["temporality.observable-counter"], .delta, file: file, line: line)
+    XCTAssertEqual(temporalities["temporality.histogram"], .delta, file: file, line: line)
+    XCTAssertEqual(
+      temporalities["temporality.up-down-counter"], .cumulative, file: file, line: line)
+    XCTAssertEqual(
+      temporalities["temporality.observable-up-down-counter"],
+      .cumulative,
+      file: file,
+      line: line)
+  }
+
+  private func assertDeltaPreferredMapping(
+    on exporter: MetricExporter,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    XCTAssertEqual(
+      exporter.getAggregationTemporality(for: .counter), .delta, file: file, line: line)
+    XCTAssertEqual(
+      exporter.getAggregationTemporality(for: .observableCounter),
+      .delta,
+      file: file,
+      line: line)
+    XCTAssertEqual(
+      exporter.getAggregationTemporality(for: .histogram), .delta, file: file, line: line)
+    XCTAssertEqual(
+      exporter.getAggregationTemporality(for: .upDownCounter),
+      .cumulative,
+      file: file,
+      line: line)
+    XCTAssertEqual(
+      exporter.getAggregationTemporality(for: .observableUpDownCounter),
+      .cumulative,
+      file: file,
+      line: line)
+  }
+}

--- a/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
+++ b/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
@@ -130,6 +130,27 @@ class OpenTelemetryInitializer {
     self.persistenceBaseDirectory = persistenceBaseDirectory
   }
 
+  static func makeGrpcMetricExporter(
+    channel: GRPCChannel,
+    config: OtlpConfiguration
+  ) -> OtlpMetricExporter {
+    OtlpMetricExporter(
+      channel: channel,
+      config: config,
+      aggregationTemporalitySelector: AggregationTemporality.deltaPreferred(),
+      logger: Logger(label: Self.logLabel))
+  }
+
+  static func makeHttpMetricExporter(
+    endpoint: URL,
+    config: OtlpConfiguration
+  ) -> OtlpHttpMetricExporter {
+    OtlpHttpMetricExporter(
+      endpoint: endpoint,
+      config: config,
+      aggregationTemporalitySelector: AggregationTemporality.deltaPreferred())
+  }
+
   // swiftlint:disable:next function_body_length
   func initialize(_ configuration: AgentConfigManager) -> LogRecordExporter {
 
@@ -172,8 +193,8 @@ class OpenTelemetryInitializer {
     let channel = OpenTelemetryHelper.makeChannel(target: channelTarget, group: group)
 
     let metricExporter = {
-      let defaultExporter = OtlpMetricExporter(
-        channel: channel, config: otlpConfiguration, logger: Logger(label: Self.logLabel))
+      let defaultExporter = Self.makeGrpcMetricExporter(
+        channel: channel, config: otlpConfiguration)
       do {
         if let path = Self.createPersistenceFolder(
           for: .metrics,
@@ -269,7 +290,8 @@ class OpenTelemetryInitializer {
 
     let metricExporter = {
       let metricEndpoint = URL(string: endpoint.absoluteString + "/v1/metrics")
-      let defaultExporter = OtlpHttpMetricExporter(endpoint: metricEndpoint ?? endpoint, config: otlpConfiguration)
+      let defaultExporter = Self.makeHttpMetricExporter(
+        endpoint: metricEndpoint ?? endpoint, config: otlpConfiguration)
       do {
         if let path = Self.createPersistenceFolder(
           for: .metrics,


### PR DESCRIPTION
## Summary

Configure metric exports to prefer delta temporality while keeping up-down counters cumulative.

## Changes

- Apply the delta-preferred selector to gRPC and HTTP metric exporters.
- Align the collecting test exporter with the agent temporality policy.
- Add exported-metric coverage for synchronous, observable, histogram, and persistence-wrapped paths.