### PR TITLE
fix: exclude SDK-owned network requests from tracing

### DIFF
--- a/.github/scripts/e2e-test/README.md
+++ b/.github/scripts/e2e-test/README.md
@@ -12,13 +12,14 @@ The test:
 2. Builds the integration app in Release configuration with a dSYM.
 3. Installs and launches the app in a fresh iOS Simulator.
 4. Finds the app's span, log record, and metric in Elasticsearch.
-5. Terminates the base launch, relaunches the app in crash mode, and verifies
+5. Verifies that the SDK's OTLP export requests produced no URLSession spans.
+6. Terminates the base launch, relaunches the app in crash mode, and verifies
    that the process exits.
-6. Relaunches the app normally and finds the persisted `app.crash` event in
+7. Relaunches the app normally and finds the persisted `app.crash` event in
    Elasticsearch.
-7. Verifies the service name, service version, and telemetry SDK name on each
+8. Verifies the service name, service version, and telemetry SDK name on each
    base-signal document.
-8. Verifies that the crash event has non-empty `exception.type` and
+9. Verifies that the crash event has non-empty `exception.type` and
    `exception.stacktrace` attributes.
 
 Every query includes a unique `test.run_id` resource attribute. The harness

--- a/.github/scripts/e2e-test/e2e_test.sh
+++ b/.github/scripts/e2e-test/e2e_test.sh
@@ -129,6 +129,38 @@ span_query() {
   }'
 }
 
+exporter_span_query() {
+  local filters
+  local collector_base_url="http://$OTLP_HOST:$OTLP_HTTP_PORT"
+  filters=$(service_filter)
+  jq -nc \
+    --argjson filters "$filters" \
+    --arg collector_base_url "$collector_base_url" \
+    '{
+      query: {
+        bool: {
+          filter: ($filters + [{
+            bool: {
+              should: [
+                {
+                  terms: {
+                    "attributes.url.path": [
+                      "/v1/traces",
+                      "/v1/metrics",
+                      "/v1/logs"
+                    ]
+                  }
+                },
+                {prefix: {"attributes.url.full": $collector_base_url}}
+              ],
+              minimum_should_match: 1
+            }
+          }])
+        }
+      }
+    }'
+}
+
 log_query() {
   local filters
   filters=$(service_filter)
@@ -216,6 +248,35 @@ es_search() {
     return 1
   fi
   echo "$response" | jq -c '.hits.hits[0]'
+}
+
+assert_no_exporter_spans() {
+  local query
+  local response
+  local count
+  local sample_response
+
+  echo "Waiting for any follow-up exporter spans..."
+  sleep 15
+  query=$(exporter_span_query)
+  echo "$query" | jq . > "$BUILD_DIR/exporter-span-count-query.json"
+  response=$(curl --fail --silent --show-error \
+    -H "Content-Type: application/json" \
+    --data "$query" \
+    "$ELASTICSEARCH_URL/traces-*/_count")
+  echo "$response" | jq . > "$BUILD_DIR/exporter-span-count-response.json"
+  count=$(echo "$response" | jq -r '.count // 0')
+
+  if [ "$count" -gt 0 ]; then
+    sample_response=$(curl --fail --silent --show-error \
+      -H "Content-Type: application/json" \
+      --data "$(echo "$query" | jq '. + {size: 1}')" \
+      "$ELASTICSEARCH_URL/traces-*/_search")
+    echo "$sample_response" | jq . > "$BUILD_DIR/exporter-span-sample.json"
+    fail "Found $count SDK exporter span(s). Sample: $(echo "$sample_response" | jq -c '.hits.hits[0]')"
+  fi
+
+  echo "Verified zero SDK exporter spans"
 }
 
 es_wait_for_item() {
@@ -503,6 +564,7 @@ metric_document=$(es_wait_for_item \
   "metric named 'e2e.launches'" \
   "metric-document")
 assert_identity "$metric_document" "Metric document"
+assert_no_exporter_spans
 
 echo "Triggering intentional app crash..."
 xcrun simctl terminate "$simulator_udid" "$APP_BUNDLE_ID" >/dev/null 2>&1 || true

--- a/.github/scripts/e2e-test/e2e_test.sh
+++ b/.github/scripts/e2e-test/e2e_test.sh
@@ -131,7 +131,7 @@ span_query() {
 
 exporter_span_query() {
   local filters
-  local collector_base_url="http://$OTLP_HOST:$OTLP_HTTP_PORT"
+  local collector_base_url="http://$OTLP_HOST:$OTLP_HTTP_PORT/"
   filters=$(service_filter)
   jq -nc \
     --argjson filters "$filters" \
@@ -139,23 +139,18 @@ exporter_span_query() {
     '{
       query: {
         bool: {
-          filter: ($filters + [{
-            bool: {
-              should: [
-                {
-                  terms: {
-                    "attributes.url.path": [
-                      "/v1/traces",
-                      "/v1/metrics",
-                      "/v1/logs"
-                    ]
-                  }
-                },
-                {prefix: {"attributes.url.full": $collector_base_url}}
-              ],
-              minimum_should_match: 1
+          filter: ($filters + [
+            {prefix: {"attributes.url.full": $collector_base_url}},
+            {
+              terms: {
+                "attributes.url.path": [
+                  "/v1/traces",
+                  "/v1/metrics",
+                  "/v1/logs"
+                ]
+              }
             }
-          }])
+          ])
         }
       }
     }'

--- a/Sources/Tests/apm-agent-iosTests/InstrumentationWrapperTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/InstrumentationWrapperTests.swift
@@ -12,6 +12,10 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
+import ElasticApmTestSupport
+import Foundation
+import NIO
+import OpenTelemetryApi
 import OpenTelemetrySdk
 import URLSessionInstrumentation
 import XCTest
@@ -37,11 +41,163 @@ final class InstrumentationWrapperTests: XCTestCase {
     }
   }
 
-  private func makeWrapper(useLegacyAttributeNames: Bool) -> InstrumentationWrapper {
-    let agentConfiguration = AgentConfigBuilder()
+  func testURLSessionConfigurationExcludesRegisteredHTTPSignalEndpoints() throws {
+    let exportURL = URL(string: "https://export.example.com:4318/otlp")!
+    let manager = makeManager(exportURL: exportURL)
+    initializeWithInjectedExporters(manager, connectionType: .http)
+    let shouldInstrument = try XCTUnwrap(
+      InstrumentationWrapper(config: manager)
+        .makeURLSessionInstrumentationConfiguration()
+        .shouldInstrument)
+
+    let registeredURLs = [
+      URL(string: "\(exportURL)/v1/traces")!,
+      URL(string: "\(exportURL)/v1/metrics")!,
+      URL(string: "\(exportURL)/v1/logs")!
+    ]
+    XCTAssertEqual(manager.registeredEndpointCount, registeredURLs.count)
+    for url in registeredURLs {
+      XCTAssertEqual(
+        shouldInstrument(URLRequest(url: url)),
+        false,
+        "Expected \(url) to be excluded")
+    }
+
+    XCTAssertEqual(
+      shouldInstrument(
+        URLRequest(url: URL(string: "\(exportURL)/v1/traces?retry=1")!)),
+      false)
+    XCTAssertNotEqual(
+      shouldInstrument(URLRequest(url: URL(string: "\(exportURL)/v1/forecast")!)),
+      false)
+    XCTAssertNotEqual(
+      shouldInstrument(
+        URLRequest(url: URL(string: "https://export.example.com:4318/v1/traces")!)),
+      false)
+    XCTAssertNotEqual(
+      shouldInstrument(
+        URLRequest(url: URL(string: "https://app.example.com:4318/otlp/v1/traces")!)),
+      false)
+  }
+
+  func testURLSessionConfigurationExcludesGrpcEndpoint() throws {
+    let exportURL = URL(string: "https://export.example.com:4318/otlp")!
+    let manager = makeManager(exportURL: exportURL)
+    initializeWithInjectedExporters(manager, connectionType: .grpc)
+    let shouldInstrument = try XCTUnwrap(
+      InstrumentationWrapper(config: manager)
+        .makeURLSessionInstrumentationConfiguration()
+        .shouldInstrument)
+
+    XCTAssertEqual(manager.registeredEndpointCount, 1)
+    XCTAssertEqual(shouldInstrument(URLRequest(url: exportURL)), false)
+  }
+
+  func testURLSessionConfigurationNormalizesRegisteredTargets() throws {
+    let exportURL = URL(string: "https://EXPORT.example.com/otlp")!
+    let manager = makeManager(exportURL: exportURL)
+    initializeWithInjectedExporters(manager, connectionType: .http)
+    let shouldInstrument = try XCTUnwrap(
+      InstrumentationWrapper(config: manager)
+        .makeURLSessionInstrumentationConfiguration()
+        .shouldInstrument)
+
+    XCTAssertEqual(
+      shouldInstrument(
+        URLRequest(
+          url: URL(string: "https://export.example.com:443/otlp/v1/traces/?retry=1#result")!
+        )),
+      false)
+  }
+
+  func testURLSessionConfigurationExcludesDerivedManagementURL() throws {
+    let exportURL = URL(string: "https://export.example.com:4318/otlp")!
+    let manager = makeManager(exportURL: exportURL, enableOpAMP: true)
+    let shouldInstrument = try XCTUnwrap(
+      InstrumentationWrapper(config: manager)
+        .makeURLSessionInstrumentationConfiguration()
+        .shouldInstrument)
+
+    XCTAssertEqual(
+      shouldInstrument(
+        URLRequest(url: URL(string: "\(exportURL)/config/v1/agents/?retry=1")!)),
+      false)
+  }
+
+  func testURLSessionConfigurationExcludesExplicitManagementURLOnly() throws {
+    let exportURL = URL(string: "https://export.example.com:4318")!
+    let managementURL = URL(string: "https://management.example.com:8443/custom/config/")!
+    let manager = makeManager(
+      exportURL: exportURL,
+      managementURL: managementURL,
+      enableOpAMP: true)
+    let shouldInstrument = try XCTUnwrap(
+      InstrumentationWrapper(config: manager)
+        .makeURLSessionInstrumentationConfiguration()
+        .shouldInstrument)
+
+    XCTAssertEqual(
+      shouldInstrument(URLRequest(url: managementURL)),
+      false)
+    XCTAssertNotEqual(
+      shouldInstrument(
+        URLRequest(url: URL(string: "\(exportURL)/config/v1/agents")!)),
+      false)
+  }
+
+  func testURLSessionConfigurationExcludesFallbackManagementURL() throws {
+    let manager = makeManager(enableOpAMP: true)
+    let shouldInstrument = try XCTUnwrap(
+      InstrumentationWrapper(config: manager)
+        .makeURLSessionInstrumentationConfiguration()
+        .shouldInstrument)
+
+    XCTAssertEqual(
+      shouldInstrument(
+        URLRequest(url: URL(string: "http://localhost:4320/v1/opamp")!)),
+      false)
+  }
+
+  func testURLSessionConfigurationDoesNotExcludeWhenExportURLCannotBeResolved() throws {
+    let manager = makeManager()
+    initializeWithInjectedExporters(manager, connectionType: .http)
+    let shouldInstrument = try XCTUnwrap(
+      InstrumentationWrapper(config: manager)
+        .makeURLSessionInstrumentationConfiguration()
+        .shouldInstrument)
+
+    XCTAssertEqual(manager.registeredEndpointCount, 0)
+    XCTAssertNotEqual(
+      shouldInstrument(
+        URLRequest(url: URL(string: "https://export.example.com:4318/v1/traces")!)),
+      false)
+  }
+
+  private func makeWrapper(
+    useLegacyAttributeNames: Bool = false
+  ) -> InstrumentationWrapper {
+    InstrumentationWrapper(
+      config: makeManager(useLegacyAttributeNames: useLegacyAttributeNames))
+  }
+
+  private func makeManager(
+    useLegacyAttributeNames: Bool = false,
+    exportURL: URL? = nil,
+    managementURL: URL? = nil,
+    enableOpAMP: Bool = false
+  ) -> AgentConfigManager {
+    let builder = AgentConfigBuilder()
       .withRemoteManagement(false)
       .useLegacyAttributeNames(useLegacyAttributeNames)
-      .build()
+    if let exportURL {
+      _ = builder.withExportUrl(exportURL)
+    }
+    if let managementURL {
+      _ = builder.withManagementUrl(managementURL)
+    }
+    if enableOpAMP {
+      _ = builder.useOpAMP()
+    }
     let instrumentationConfiguration = InstrumentationConfigBuilder()
       .withLifecycleEvents(false)
       .withViewControllerInstrumentation(false)
@@ -49,9 +205,38 @@ final class InstrumentationWrapperTests: XCTestCase {
       .build()
     let manager = AgentConfigManager(
       resource: Resource(),
-      config: agentConfiguration,
+      config: builder.build(),
       instrumentationConfig: instrumentationConfiguration
     )
-    return InstrumentationWrapper(config: manager)
+    return manager
+  }
+
+  private func initializeWithInjectedExporters(
+    _ manager: AgentConfigManager,
+    connectionType: AgentConnectionType
+  ) {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    let initializer = OpenTelemetryInitializer(
+      group: group,
+      sessionSampler: SessionSampler { 1.0 },
+      exporters: OpenTelemetryInitializer.Exporters(
+        metric: WaitingMetricExporter(numberToWaitFor: 1),
+        trace: WaitingSpanExporter(numberToWaitFor: 1),
+        log: WaitingLogRecordExporter(numberToWaitFor: 1)))
+
+    switch connectionType {
+    case .grpc:
+      _ = initializer.initialize(manager)
+    case .http:
+      _ = initializer.initializeWithHttp(manager)
+    }
+
+    if let tracerProvider = OpenTelemetry.instance.tracerProvider as? TracerProviderSdk {
+      tracerProvider.shutdown()
+    }
+    if let meterProvider = OpenTelemetry.instance.meterProvider as? MeterProviderSdk {
+      XCTAssertEqual(meterProvider.shutdown(), .success)
+    }
+    XCTAssertNoThrow(try group.syncShutdownGracefully())
   }
 }

--- a/Sources/Tests/apm-agent-iosTests/URLSessionExporterExclusionTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/URLSessionExporterExclusionTests.swift
@@ -1,0 +1,179 @@
+// Copyright © 2026 Elasticsearch BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+// EDOT supports iOS; macOS retains the SwiftPM development loop.
+#if os(iOS) || os(macOS)
+
+  import ElasticApmTestSupport
+  import Foundation
+  import NIO
+  import OpenTelemetryApi
+  import OpenTelemetryProtocolExporterCommon
+  import OpenTelemetryProtocolExporterHttp
+  import OpenTelemetrySdk
+  import XCTest
+
+  @testable import ElasticApm
+
+  final class URLSessionExporterExclusionTests: XCTestCase {
+    func testExporterRequestsAreExcludedWhileApplicationRequestIsInstrumented() throws {
+      let exportServer = LoopbackHTTPTestServer()
+      let applicationServer = LoopbackHTTPTestServer()
+      try exportServer.start()
+      try applicationServer.start()
+      defer {
+        applicationServer.stop()
+        exportServer.stop()
+      }
+
+      let exportURLs = [
+        exportServer.baseURL,
+        exportServer.baseURL.appendingPathComponent("otlp")
+      ]
+      let harness = URLSessionExclusionHarness(exportURLs: exportURLs)
+      defer { harness.shutDown() }
+
+      let seedSpan = try harness.makeSeedSpan()
+      for traceEndpoint in harness.traceEndpoints {
+        let realExporter = OtlpHttpTraceExporter(
+          endpoint: traceEndpoint,
+          config: OtlpConfiguration(timeout: 5),
+          envVarHeaders: [])
+        XCTAssertEqual(realExporter.export(spans: [seedSpan]), .success)
+        XCTAssertNotNil(
+          exportServer.waitForRequest(timeout: 5) { $0.path == traceEndpoint.path },
+          exportServer.diagnostics)
+      }
+
+      let requestExpectation = expectation(description: "ordinary application request")
+      URLSession.shared.dataTask(
+        with: applicationServer.baseURL.appendingPathComponent("application")
+      ) { _, response, error in
+        XCTAssertNil(error)
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        requestExpectation.fulfill()
+      }.resume()
+      wait(for: [requestExpectation], timeout: 10)
+
+      let spans = try XCTUnwrap(
+        harness.waitForInstrumentedSpans(),
+        """
+        No URLSession spans were exported.
+        Export server: \(exportServer.diagnostics)
+        Application server: \(applicationServer.diagnostics)
+        """)
+      let exporterSpans = spans.filter {
+        $0.targets(server: exportServer)
+      }
+      XCTAssertTrue(
+        exporterSpans.isEmpty,
+        "Exporter requests produced spans: \(exporterSpans)")
+
+      let applicationSpans = spans.filter {
+        $0.kind == .client
+          && $0.targets(server: applicationServer)
+          && $0.attributes[SemanticConventions.Url.path.rawValue]?.description == "/application"
+      }
+      XCTAssertEqual(
+        applicationSpans.count,
+        1,
+        "Expected exactly one application client span, got: \(spans)")
+    }
+  }
+
+  private final class URLSessionExclusionHarness {
+    private let spanExporter = WaitingSpanExporter(numberToWaitFor: 1)
+    private let logExporter = WaitingLogRecordExporter(numberToWaitFor: 1)
+    private let metricExporter = WaitingMetricExporter(numberToWaitFor: 1)
+    private let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    private let wrapper: InstrumentationWrapper
+    let traceEndpoints: [URL]
+
+    init(exportURLs: [URL]) {
+      let endpointRegistry = SDKEndpointRegistry()
+      let initializer = OpenTelemetryInitializer(
+        group: group,
+        sessionSampler: SessionSampler { 1.0 },
+        exporters: OpenTelemetryInitializer.Exporters(
+          metric: metricExporter,
+          trace: spanExporter,
+          log: logExporter))
+
+      let configManagers = exportURLs.map { exportURL in
+        AgentConfigManager(
+          resource: Resource(),
+          config: AgentConfigBuilder()
+            .withExportUrl(exportURL)
+            .withRemoteManagement(false)
+            .build(),
+          instrumentationConfig: InstrumentationConfigBuilder()
+            .withLifecycleEvents(false)
+            .withViewControllerInstrumentation(false)
+            .withSystemMetrics(false)
+            .build(),
+          endpointRegistry: endpointRegistry)
+      }
+      for configManager in configManagers {
+        _ = initializer.initializeWithHttp(configManager)
+      }
+
+      traceEndpoints = exportURLs.map {
+        URL(string: $0.absoluteString + "/v1/traces")!
+      }
+      wrapper = InstrumentationWrapper(config: configManagers[0])
+      wrapper.initalize()
+    }
+
+    func makeSeedSpan() throws -> SpanData {
+      let tracer = OpenTelemetry.instance.tracerProvider.get(
+        instrumentationName: "URLSessionExporterExclusionTests")
+      tracer.spanBuilder(spanName: "export-seed").startSpan().end()
+      let provider = try XCTUnwrap(
+        OpenTelemetry.instance.tracerProvider as? TracerProviderSdk)
+      provider.forceFlush()
+      return try XCTUnwrap(spanExporter.waitForExport()?.first)
+    }
+
+    func waitForInstrumentedSpans() -> [SpanData]? {
+      spanExporter.waitForExport()
+    }
+
+    func shutDown() {
+      if let tracerProvider = OpenTelemetry.instance.tracerProvider as? TracerProviderSdk {
+        tracerProvider.shutdown()
+      }
+      if let meterProvider = OpenTelemetry.instance.meterProvider as? MeterProviderSdk {
+        XCTAssertEqual(meterProvider.shutdown(), .success)
+      }
+      XCTAssertNoThrow(try group.syncShutdownGracefully())
+    }
+  }
+
+  private extension SpanData {
+    func targets(server: LoopbackHTTPTestServer) -> Bool {
+      if let full = attributes[SemanticConventions.Url.full.rawValue]?.description,
+         let url = URL(string: full),
+         url.host == server.baseURL.host,
+         url.port == server.port {
+        return true
+      }
+
+      return attributes[SemanticConventions.Server.address.rawValue]?.description
+        == server.baseURL.host
+        && attributes[SemanticConventions.Server.port.rawValue]?.description
+          == String(server.port)
+    }
+  }
+
+#endif

--- a/Sources/Tests/apm-agent-iosTests/URLSessionExporterExclusionTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/URLSessionExporterExclusionTests.swift
@@ -39,7 +39,8 @@
 
       let exportURLs = [
         exportServer.baseURL,
-        exportServer.baseURL.appendingPathComponent("otlp")
+        exportServer.baseURL.appendingPathComponent("otlp"),
+        URL(string: exportServer.baseURL.appendingPathComponent("otlp").absoluteString + "/")!
       ]
       let harness = URLSessionExclusionHarness(exportURLs: exportURLs)
       defer { harness.shutDown() }

--- a/Sources/Tests/apm-agent-iosTests/URLSessionExporterExclusionTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/URLSessionExporterExclusionTests.swift
@@ -37,25 +37,20 @@
         exportServer.stop()
       }
 
-      let exportURLs = [
-        exportServer.baseURL,
-        exportServer.baseURL.appendingPathComponent("otlp"),
+      let exportURL =
         URL(string: exportServer.baseURL.appendingPathComponent("otlp").absoluteString + "/")!
-      ]
-      let harness = URLSessionExclusionHarness(exportURLs: exportURLs)
+      let harness = URLSessionExclusionHarness(exportURL: exportURL)
       defer { harness.shutDown() }
 
       let seedSpan = try harness.makeSeedSpan()
-      for traceEndpoint in harness.traceEndpoints {
-        let realExporter = OtlpHttpTraceExporter(
-          endpoint: traceEndpoint,
-          config: OtlpConfiguration(timeout: 5),
-          envVarHeaders: [])
-        XCTAssertEqual(realExporter.export(spans: [seedSpan]), .success)
-        XCTAssertNotNil(
-          exportServer.waitForRequest(timeout: 5) { $0.path == traceEndpoint.path },
-          exportServer.diagnostics)
-      }
+      let realExporter = OtlpHttpTraceExporter(
+        endpoint: harness.traceEndpoint,
+        config: OtlpConfiguration(timeout: 5),
+        envVarHeaders: [])
+      XCTAssertEqual(realExporter.export(spans: [seedSpan]), .success)
+      XCTAssertNotNil(
+        exportServer.waitForRequest(timeout: 5) { $0.path == harness.traceEndpoint.path },
+        exportServer.diagnostics)
 
       let requestExpectation = expectation(description: "ordinary application request")
       URLSession.shared.dataTask(
@@ -99,9 +94,9 @@
     private let metricExporter = WaitingMetricExporter(numberToWaitFor: 1)
     private let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     private let wrapper: InstrumentationWrapper
-    let traceEndpoints: [URL]
+    let traceEndpoint: URL
 
-    init(exportURLs: [URL]) {
+    init(exportURL: URL) {
       let endpointRegistry = SDKEndpointRegistry()
       let initializer = OpenTelemetryInitializer(
         group: group,
@@ -111,28 +106,22 @@
           trace: spanExporter,
           log: logExporter))
 
-      let configManagers = exportURLs.map { exportURL in
-        AgentConfigManager(
-          resource: Resource(),
-          config: AgentConfigBuilder()
-            .withExportUrl(exportURL)
-            .withRemoteManagement(false)
-            .build(),
-          instrumentationConfig: InstrumentationConfigBuilder()
-            .withLifecycleEvents(false)
-            .withViewControllerInstrumentation(false)
-            .withSystemMetrics(false)
-            .build(),
-          endpointRegistry: endpointRegistry)
-      }
-      for configManager in configManagers {
-        _ = initializer.initializeWithHttp(configManager)
-      }
+      let configManager = AgentConfigManager(
+        resource: Resource(),
+        config: AgentConfigBuilder()
+          .withExportUrl(exportURL)
+          .withRemoteManagement(false)
+          .build(),
+        instrumentationConfig: InstrumentationConfigBuilder()
+          .withLifecycleEvents(false)
+          .withViewControllerInstrumentation(false)
+          .withSystemMetrics(false)
+          .build(),
+        endpointRegistry: endpointRegistry)
+      _ = initializer.initializeWithHttp(configManager)
 
-      traceEndpoints = exportURLs.map {
-        URL(string: $0.absoluteString + "/v1/traces")!
-      }
-      wrapper = InstrumentationWrapper(config: configManagers[0])
+      traceEndpoint = URL(string: exportURL.absoluteString + "/v1/traces")!
+      wrapper = InstrumentationWrapper(config: configManager)
       wrapper.initalize()
     }
 

--- a/Sources/apm-agent-ios/Configuration/AgentConfigManager.swift
+++ b/Sources/apm-agent-ios/Configuration/AgentConfigManager.swift
@@ -13,30 +13,106 @@
 //   limitations under the License.
 
 import Foundation
-import OpenTelemetrySdk
 import Logging
+import OpenTelemetrySdk
+
+struct URLTarget: Hashable {
+  let scheme: String
+  let host: String
+  let port: Int?
+  let path: String
+
+  init?(_ url: URL) {
+    guard
+      let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+      let scheme = components.scheme?.lowercased(),
+      let host = components.host?.lowercased()
+    else {
+      return nil
+    }
+
+    self.scheme = scheme
+    self.host = host
+    port = components.port ?? Self.defaultPort(for: scheme)
+    path = Self.normalizedPath(components.path)
+  }
+
+  private static func defaultPort(for scheme: String) -> Int? {
+    switch scheme {
+    case "http":
+      return 80
+    case "https":
+      return 443
+    default:
+      return nil
+    }
+  }
+
+  private static func normalizedPath(_ path: String) -> String {
+    var normalized = path.isEmpty ? "/" : path
+    while normalized.count > 1, normalized.hasSuffix("/") {
+      normalized.removeLast()
+    }
+    return normalized
+  }
+}
+
+final class SDKEndpointRegistry {
+  private let lock = NSLock()
+  private var targets = Set<URLTarget>()
+
+  func register(_ url: URL) {
+    guard let target = URLTarget(url) else {
+      return
+    }
+    lock.lock()
+    targets.insert(target)
+    lock.unlock()
+  }
+
+  func contains(_ url: URL) -> Bool {
+    guard let target = URLTarget(url) else {
+      return false
+    }
+    lock.lock()
+    defer { lock.unlock() }
+    return targets.contains(target)
+  }
+
+  var count: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return targets.count
+  }
+}
 
 class AgentConfigManager {
   public let agent: AgentConfiguration
   public let central: CentralConfig
   public let instrumentation: InstrumentationConfiguration
   let centralConfigManager: CentralConfigManager
-  
-  init(resource: Resource,
-       config: AgentConfiguration,
-       instrumentationConfig: InstrumentationConfiguration,
-       logger: Logging.Logger = Logging.Logger(label: "co.elastic.centralConfigFetcher") { _ in
-    SwiftLogNoOpLogHandler()
-  }) {
+  private let endpointRegistry: SDKEndpointRegistry
+
+  init(
+    resource: Resource,
+    config: AgentConfiguration,
+    instrumentationConfig: InstrumentationConfiguration,
+    endpointRegistry: SDKEndpointRegistry = SDKEndpointRegistry(),
+    logger: Logging.Logger = Logging.Logger(label: "co.elastic.centralConfigFetcher") { _ in
+      SwiftLogNoOpLogHandler()
+    }
+  ) {
     agent = config
     instrumentation = instrumentationConfig
     central = CentralConfig()
+    self.endpointRegistry = endpointRegistry
 
-    if (config.enableOpAMP) {
+    if config.enableOpAMP {
       centralConfigManager = OpampCentralConfigManager(
         resource: resource,
-        agent:config,
+        agent: config,
         instrumentationConfig: instrumentationConfig,
+        endpointRegistry: endpointRegistry,
         logger: logger
       )
     } else {
@@ -48,5 +124,16 @@ class AgentConfigManager {
       )
     }
   }
-}
 
+  func register(_ url: URL) {
+    endpointRegistry.register(url)
+  }
+
+  func isRegistered(_ url: URL) -> Bool {
+    endpointRegistry.contains(url)
+  }
+
+  var registeredEndpointCount: Int {
+    endpointRegistry.count
+  }
+}

--- a/Sources/apm-agent-ios/Configuration/OpampCentralConfigManager.swift
+++ b/Sources/apm-agent-ios/Configuration/OpampCentralConfigManager.swift
@@ -31,6 +31,7 @@ public class OpampCentralConfigManager: CentralConfigManager, OpampClientCallbac
     resource: Resource,
     agent: AgentConfiguration,
     instrumentationConfig: InstrumentationConfiguration,
+    endpointRegistry: SDKEndpointRegistry,
     logger: Logging.Logger = Logging.Logger(label: "co.elastic.centralConfig.opamp") { _ in
       SwiftLogNoOpLogHandler()
     }
@@ -72,19 +73,23 @@ public class OpampCentralConfigManager: CentralConfigManager, OpampClientCallbac
     builder.enableRemoteConfig()
     builder.enableEffectiveConfigReporting()
 
-    let httpClient = {
+    let configuredManagementURL = agent.managementUrlComponents().url.flatMap {
+      URLTarget($0) == nil ? nil : $0
+    }
+    let managementURL =
+      configuredManagementURL ?? URL(string: "http://localhost:4320/v1/opamp")!
+    endpointRegistry.register(managementURL)
 
-      if let url = agent.managementUrlComponents().url {
-        return OpampHttpSender(
-          url: url,
-          headers: OpenTelemetryHelper.generateExporterHeaders(agent.auth)
-        )
-      } else
-      {
-        logger.error("Unable to parse manament url; using default: http://localhost:4320/v1/opamp")
-        return OpampHttpSender(url: URL(string: "http://localhost:4320/v1/opamp")!)
-      }
-    }()
+    let httpClient: OpampHttpSender
+    if configuredManagementURL != nil {
+      httpClient = OpampHttpSender(
+        url: managementURL,
+        headers: OpenTelemetryHelper.generateExporterHeaders(agent.auth)
+      )
+    } else {
+      logger.error("Unable to parse manament url; using default: http://localhost:4320/v1/opamp")
+      httpClient = OpampHttpSender(url: managementURL)
+    }
 
     let requestService = OpampHttpRequestService(
       httpClient: httpClient

--- a/Sources/apm-agent-ios/Configuration/OpampCentralConfigManager.swift
+++ b/Sources/apm-agent-ios/Configuration/OpampCentralConfigManager.swift
@@ -87,7 +87,7 @@ public class OpampCentralConfigManager: CentralConfigManager, OpampClientCallbac
         headers: OpenTelemetryHelper.generateExporterHeaders(agent.auth)
       )
     } else {
-      logger.error("Unable to parse manament url; using default: http://localhost:4320/v1/opamp")
+      logger.error("Unable to parse management url; using default: http://localhost:4320/v1/opamp")
       httpClient = OpampHttpSender(url: managementURL)
     }
 

--- a/Sources/apm-agent-ios/InstrumentationWrapper.swift
+++ b/Sources/apm-agent-ios/InstrumentationWrapper.swift
@@ -87,9 +87,14 @@ class InstrumentationWrapper {
 
   func makeURLSessionInstrumentationConfiguration()
     -> URLSessionInstrumentationConfiguration {
-    URLSessionInstrumentationConfiguration(
+    return URLSessionInstrumentationConfiguration(
       shouldRecordPayload: nil,
-      shouldInstrument: nil,
+      shouldInstrument: { request in
+        guard let url = request.url else {
+          return nil
+        }
+        return self.config.isRegistered(url) ? false : nil
+      },
 
       nameSpan: { request in
         if let host = request.url?.host,
@@ -99,15 +104,7 @@ class InstrumentationWrapper {
         return nil
       },
       shouldInjectTracingHeaders: nil,
-      createdRequest: { request, span in
-        print(
-          "request to: ",
-          request.httpMethod ?? "n/a",
-          request.url?.absoluteString ?? "n/a"
-        )
-        print("span", span.context.traceId)
-        print("span", span.context.spanId)
-
+      createdRequest: { _, span in
         #if os(iOS) && !targetEnvironment(macCatalyst)
           if let injector = self.netstatInjector {
             injector.inject(span: span)

--- a/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
+++ b/Sources/apm-agent-ios/OpenTelemetryInitializer.swift
@@ -172,6 +172,9 @@ class OpenTelemetryInitializer {
     let resources = AgentResource.get(
       useLegacyAttributeNames: configuration.agent.useLegacyAttributeNames
     ).merging(other: AgentEnvResource.get())
+    if let endpoint = OpenTelemetryHelper.getURL(with: configuration.agent) {
+      configuration.register(endpoint)
+    }
     if let exporters {
       return registerProviders(
         configuration: configuration,
@@ -272,6 +275,20 @@ class OpenTelemetryInitializer {
     let resources = AgentResource.get(
       useLegacyAttributeNames: configuration.agent.useLegacyAttributeNames
     ).merging(other: AgentEnvResource.get())
+    let endpoint = OpenTelemetryHelper.getURL(with: configuration.agent)
+    let metricEndpoint = endpoint.map {
+      URL(string: $0.absoluteString + "/v1/metrics") ?? $0
+    }
+    let traceEndpoint = endpoint.map {
+      URL(string: $0.absoluteString + "/v1/traces") ?? $0
+    }
+    let logsEndpoint = endpoint.map {
+      URL(string: $0.absoluteString + "/v1/logs") ?? $0
+    }
+    for endpoint in [metricEndpoint, traceEndpoint, logsEndpoint].compactMap({ $0 }) {
+      configuration.register(endpoint)
+    }
+
     if let exporters {
       return registerProviders(
         configuration: configuration,
@@ -279,7 +296,7 @@ class OpenTelemetryInitializer {
         exporters: exporters)
     }
 
-    guard let endpoint =  OpenTelemetryHelper.getURL(with: configuration.agent) else {
+    guard let endpoint, let metricEndpoint, let traceEndpoint, let logsEndpoint else {
       os_log("Failed to start Elastic agent: invalid collector url.")
       return NoopLogRecordExporter.instance
     }
@@ -289,9 +306,8 @@ class OpenTelemetryInitializer {
       headers: OpenTelemetryHelper.generateExporterHeaders(configuration.agent.auth))
 
     let metricExporter = {
-      let metricEndpoint = URL(string: endpoint.absoluteString + "/v1/metrics")
       let defaultExporter = Self.makeHttpMetricExporter(
-        endpoint: metricEndpoint ?? endpoint, config: otlpConfiguration)
+        endpoint: metricEndpoint, config: otlpConfiguration)
       do {
         if let path = Self.createPersistenceFolder(
           for: .metrics,
@@ -306,9 +322,8 @@ class OpenTelemetryInitializer {
     }()
 
     let traceExporter = {
-      let traceEndpoint = URL(string: endpoint.absoluteString + "/v1/traces")
       let defaultExporter = OtlpHttpTraceExporter(
-        endpoint: traceEndpoint ?? endpoint, config: otlpConfiguration)
+        endpoint: traceEndpoint, config: otlpConfiguration)
       do {
         if let path = Self.createPersistenceFolder(
           for: .traces,
@@ -324,8 +339,9 @@ class OpenTelemetryInitializer {
     }()
 
     let logExporter = {
-      let logsEndpoint = URL(string: endpoint.absoluteString + "/v1/logs")
-      let defaultExporter = OtlpHttpLogExporter(endpoint: logsEndpoint ?? endpoint, config: otlpConfiguration)
+      let defaultExporter = OtlpHttpLogExporter(
+        endpoint: logsEndpoint,
+        config: otlpConfiguration)
       do {
         if let path = Self.createPersistenceFolder(
           for: .logs,


### PR DESCRIPTION
## Summary

Prevents URLSession instrumentation from creating spans for requests made by SDK-owned exporters and central configuration.

## Changes

- Register normalized final OTLP and OpAMP endpoint URLs before exporters start.
- Exclude only registered SDK endpoint requests while preserving application requests to other URLs.
- Add decision, exported-span, and end-to-end regression coverage.