### PR TITLE
Add app installation resource identity

### DIFF
--- a/Sources/Tests/apm-agent-iosTests/InstallationIdProviderTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/InstallationIdProviderTests.swift
@@ -18,6 +18,44 @@ import XCTest
 @testable import ElasticApm
 
 final class InstallationIdProviderTests: XCTestCase {
+  func testResourceOverridePreservesFallbackInstallationId() throws {
+    let userDefaults = UserDefaults.standard
+    let storageKey = InstallationIdProvider.storageKey
+    let previousValue = userDefaults.object(forKey: storageKey)
+    defer {
+      if let previousValue = previousValue {
+        userDefaults.set(previousValue, forKey: storageKey)
+      } else {
+        userDefaults.removeObject(forKey: storageKey)
+      }
+    }
+
+    let override = "configured-installation-id"
+    let environment = [
+      AgentEnvResource.otelResourceAttributesEnv: "app.installation.id=\(override)"
+    ]
+
+    for useLegacyAttributeNames in [false, true] {
+      userDefaults.removeObject(forKey: storageKey)
+      let resource = AgentResource.get(
+        useLegacyAttributeNames: useLegacyAttributeNames
+      ).merging(other: AgentEnvResource.get(environment))
+
+      XCTAssertEqual(resource.attributes["app.installation.id"], .string(override))
+      // Read storage directly so the assertion cannot generate a missing fallback.
+      let fallback = try XCTUnwrap(userDefaults.string(forKey: storageKey))
+      XCTAssertNotNil(UUID(uuidString: fallback))
+      XCTAssertNotEqual(fallback, override)
+
+      let resourceWithoutOverride = AgentResource.get(
+        useLegacyAttributeNames: useLegacyAttributeNames
+      ).merging(other: AgentEnvResource.get([:]))
+
+      XCTAssertEqual(resourceWithoutOverride.attributes["app.installation.id"], .string(fallback))
+      XCTAssertEqual(userDefaults.string(forKey: storageKey), fallback)
+    }
+  }
+
   func testConcurrentFirstReadsReturnSameInstallationId() throws {
     let suiteName = "InstallationIdProviderTests.\(UUID().uuidString)"
     let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/Sources/Tests/apm-agent-iosTests/InstallationIdProviderTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/InstallationIdProviderTests.swift
@@ -18,6 +18,29 @@ import XCTest
 @testable import ElasticApm
 
 final class InstallationIdProviderTests: XCTestCase {
+  func testConcurrentFirstReadsReturnSameInstallationId() throws {
+    let suiteName = "InstallationIdProviderTests.\(UUID().uuidString)"
+    let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    userDefaults.removePersistentDomain(forName: suiteName)
+    defer {
+      userDefaults.removePersistentDomain(forName: suiteName)
+    }
+
+    let valuesLock = NSLock()
+    var values = [String]()
+
+    DispatchQueue.concurrentPerform(iterations: 100) { _ in
+      let value = InstallationIdProvider(userDefaults: userDefaults).get()
+      valuesLock.lock()
+      values.append(value)
+      valuesLock.unlock()
+    }
+
+    let persistedValue = try XCTUnwrap(
+      userDefaults.string(forKey: InstallationIdProvider.storageKey))
+    XCTAssertEqual(Set(values), [persistedValue])
+  }
+
   func testPersistsAndRegeneratesInstallationId() throws {
     let suiteName = "InstallationIdProviderTests.\(UUID().uuidString)"
     let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/Sources/Tests/apm-agent-iosTests/InstallationIdProviderTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/InstallationIdProviderTests.swift
@@ -1,0 +1,47 @@
+// Copyright © 2026 Elasticsearch BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+import Foundation
+import XCTest
+
+@testable import ElasticApm
+
+final class InstallationIdProviderTests: XCTestCase {
+  func testPersistsAndRegeneratesInstallationId() throws {
+    let suiteName = "InstallationIdProviderTests.\(UUID().uuidString)"
+    let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    userDefaults.removePersistentDomain(forName: suiteName)
+    defer {
+      userDefaults.removePersistentDomain(forName: suiteName)
+    }
+
+    let provider = InstallationIdProvider(userDefaults: userDefaults)
+    let first = provider.get()
+
+    XCTAssertNotNil(UUID(uuidString: first))
+    XCTAssertEqual(provider.get(), first)
+
+    userDefaults.removeObject(forKey: InstallationIdProvider.storageKey)
+    let replacement = provider.get()
+
+    XCTAssertNotNil(UUID(uuidString: replacement))
+    XCTAssertNotEqual(replacement, first)
+
+    userDefaults.set("invalid", forKey: InstallationIdProvider.storageKey)
+    let repaired = provider.get()
+
+    XCTAssertNotNil(UUID(uuidString: repaired))
+    XCTAssertNotEqual(repaired, "invalid")
+  }
+}

--- a/Sources/Tests/apm-agent-iosTests/TelemetryAttributeSmokeTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/TelemetryAttributeSmokeTests.swift
@@ -39,6 +39,7 @@ final class ResourceAttributeSmokeTests: XCTestCase {
       XCTAssertEqual(span.resource.attributes, expected)
       XCTAssertEqual(log.resource.attributes, expected)
       XCTAssertEqual(metric.resource.attributes, expected)
+      XCTAssertNotNil(span.resource.attributes["app.installation.id"])
       XCTAssertNil(span.resource.attributes["service.build"])
       XCTAssertNotEqual(
         span.resource.attributes["telemetry.sdk.version"],
@@ -240,8 +241,10 @@ private func expectedResourceAttributes(
 ) throws -> [String: AttributeValue] {
   let application = ApplicationDataSource()
   let device = DeviceDataSource()
+  let installationId = InstallationIdProvider().get()
   let operatingSystem = OperatingSystemDataSource()
   var expected: [String: AttributeValue] = [
+    "app.installation.id": .string(installationId),
     "service.name": .string(
       application.name ?? "unknown_service:\(ProcessInfo.processInfo.processName)"),
     "deployment.environment.name": .string("default"),

--- a/Sources/apm-agent-ios/AgentResource.swift
+++ b/Sources/apm-agent-ios/AgentResource.swift
@@ -13,13 +13,6 @@
 //   limitations under the License.
 
 import Foundation
-#if os(watchOS)
-import WatchKit
-#elseif os(macOS)
-import AppKit
-#else
-import UIKit
-#endif
 import ResourceExtension
 import OpenTelemetryApi
 import OpenTelemetrySdk
@@ -48,10 +41,9 @@ public class AgentResource {
       .string(osDataSource.name)
     overridingAttributes[SemanticConventions.Process.runtimeVersion.rawValue] =
       AttributeValue.string(osDataSource.version)
-    if let deviceId = AgentResource.identifier() {
-      overridingAttributes[SemanticConventions.Device.id.rawValue] = AttributeValue
-        .string(deviceId)
-    }
+    let installationId = InstallationIdProvider().get()
+    overridingAttributes[SemanticConventions.App.installationId.rawValue] = AttributeValue
+      .string(installationId)
     let appDataSource = ApplicationDataSource()
 
     if let build = appDataSource.build {
@@ -77,20 +69,4 @@ public class AgentResource {
 
     return defaultResource.merging(other: Resource.init(attributes: overridingAttributes))
   }
-
-  static private func identifier() -> String? {
-#if os(watchOS)
-    if #available(watchOS 6.3, *) {
-      return WKInterfaceDevice.current().identifierForVendor?.uuidString
-    } else {
-      return nil
-    }
-#elseif os(macOS)
-    return nil
-#else
-    return UIDevice.current.identifierForVendor?.uuidString
-
-#endif
-  }
-
 }

--- a/Sources/apm-agent-ios/InstallationIdProvider.swift
+++ b/Sources/apm-agent-ios/InstallationIdProvider.swift
@@ -16,6 +16,7 @@ import Foundation
 
 struct InstallationIdProvider {
   static let storageKey = "elastic.app.installation.id"
+  private static let storageLock = NSLock()
 
   private let userDefaults: UserDefaults
 
@@ -24,9 +25,11 @@ struct InstallationIdProvider {
   }
 
   func get() -> String {
+    Self.storageLock.lock()
+    defer { Self.storageLock.unlock() }
+
     if let storedValue = userDefaults.string(forKey: Self.storageKey),
-      UUID(uuidString: storedValue) != nil
-    {
+      UUID(uuidString: storedValue) != nil {
       return storedValue
     }
 

--- a/Sources/apm-agent-ios/InstallationIdProvider.swift
+++ b/Sources/apm-agent-ios/InstallationIdProvider.swift
@@ -1,0 +1,37 @@
+// Copyright © 2026 Elasticsearch BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+import Foundation
+
+struct InstallationIdProvider {
+  static let storageKey = "elastic.app.installation.id"
+
+  private let userDefaults: UserDefaults
+
+  init(userDefaults: UserDefaults = .standard) {
+    self.userDefaults = userDefaults
+  }
+
+  func get() -> String {
+    if let storedValue = userDefaults.string(forKey: Self.storageKey),
+      UUID(uuidString: storedValue) != nil
+    {
+      return storedValue
+    }
+
+    let installationId = UUID().uuidString
+    userDefaults.set(installationId, forKey: Self.storageKey)
+    return installationId
+  }
+}

--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -468,6 +468,11 @@ The available upstream presets are:
 
 EDOT iOS detects app, device, operating system, process, and telemetry SDK resource attributes. It also reads custom resource attributes from `OTEL_RESOURCE_ATTRIBUTES`.
 
+The resource includes `app.installation.id`, a random UUID created on first
+launch and persisted in `UserDefaults` for the lifetime of the installation.
+The value resets when the app is uninstalled and is never derived from a device
+identifier.
+
 You can provide this value through the process environment or your app's `Info.plist`:
 
 ```xml

--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -468,12 +468,14 @@ The available upstream presets are:
 
 EDOT iOS detects app, device, operating system, process, and telemetry SDK resource attributes. It also reads custom resource attributes from `OTEL_RESOURCE_ATTRIBUTES`.
 
-The resource includes `app.installation.id`, a random UUID created on first
-launch and persisted in `UserDefaults` for the lifetime of the installation.
-The value resets when the app is uninstalled and is never derived from a device
-identifier.
+By default, the resource includes `app.installation.id`, a random UUID created
+the first time the app opens and persisted in `UserDefaults` for the lifetime
+of the installation. The default value resets when the app is uninstalled and
+is never derived from a device identifier.
 
-You can provide this value through the process environment or your app's `Info.plist`:
+To override this identifier or provide other custom resource attributes, set
+`OTEL_RESOURCE_ATTRIBUTES` in the process environment or your app's
+`Info.plist`:
 
 ```xml
 <key>OTEL_RESOURCE_ATTRIBUTES</key>

--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -468,10 +468,11 @@ The available upstream presets are:
 
 EDOT iOS detects app, device, operating system, process, and telemetry SDK resource attributes. It also reads custom resource attributes from `OTEL_RESOURCE_ATTRIBUTES`.
 
-By default, the resource includes `app.installation.id`, a random UUID created
-the first time the app opens and persisted in `UserDefaults` for the lifetime
-of the installation. The default value resets when the app is uninstalled and
-is never derived from a device identifier.
+{applies_to}`edot_ios: ga 2.1.0` By default, the resource includes
+`app.installation.id`, a random UUID created the first time the app opens and
+persisted in `UserDefaults` for the lifetime of the installation. The default
+value resets when the app is uninstalled and is never derived from a device
+identifier.
 
 To override this identifier or provide other custom resource attributes, set
 `OTEL_RESOURCE_ATTRIBUTES` in the process environment or your app's


### PR DESCRIPTION
## Summary
Add a persistent installation identifier to EDOT iOS resources while retaining the upstream device identity behavior.

## Changes
- Generate and persist `app.installation.id` for the lifetime of an installation.
- Remove the duplicate SDK-owned `device.id` assignment and identifier helper.
- Cover resource identity in both attribute-name modes and document the installation identifier.