### PR TITLE
fix: harden network status initialization

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/ashleymills/Reachability.swift", from: "5.2.4"),
     .package(
-      url: "https://github.com/open-telemetry/opentelemetry-swift", from: "2.2.1"),
+      url: "https://github.com/open-telemetry/opentelemetry-swift", from: "2.4.1"),
     .package(
       url: "https://github.com/open-telemetry/opentelemetry-swift-core", from: "2.3.0"),
     .package(url: "https://github.com/MobileNativeFoundation/Kronos.git", .upToNextMajor(from: "4.2.2")),

--- a/Sources/apm-agent-ios/Utils/NetworkStatusManager.swift
+++ b/Sources/apm-agent-ios/Utils/NetworkStatusManager.swift
@@ -12,7 +12,6 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-
 #if os(iOS) && !targetEnvironment(macCatalyst)
 
 import Foundation
@@ -29,22 +28,10 @@ class NetworkStatusManager {
     }
   }
 
-  private static var instance: NetworkStatus?
-
-  private static func shared() -> NetworkStatus? {
-    guard let existingInstance = instance else {
-      do {
-        Self.instance = try NetworkStatus()
-        return Self.instance
-      } catch {
-        return nil
-      }
-    }
-    return existingInstance
-  }
+  private static let instance: NetworkStatus? = try? NetworkStatus()
 
   func status() -> String {
-    guard let currentInstance = Self.shared() else {
+    guard let currentInstance = Self.instance else {
       return "unavailable"
     }
 


### PR DESCRIPTION
## Summary

Make network status initialization deterministic and require a dependency version that includes the corresponding synchronization improvements.

## Changes

- Initialize the shared network status helper once using Swift static initialization.
- Raise the compatible dependency minimum to 2.4.1.