### PR TITLE
docs: refresh iOS SDK documentation wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to the APM Agent
+# Contributing to EDOT iOS
 
-The APM Agent is open source and we love to receive contributions from our community — you!
+EDOT iOS is open source and we love to receive contributions from our community — you!
 
 There are many ways to contribute,
 from writing tutorials or blog posts,

--- a/README.md
+++ b/README.md
@@ -1,21 +1,11 @@
-[![macos](https://github.com/elastic/apm-agent-ios/actions/workflows/macos.yml/badge.svg)](https://github.com/elastic/apm-agent-ios/actions/workflows/macos.yml)
+[![Build and Test](https://github.com/elastic/apm-agent-ios/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/elastic/apm-agent-ios/actions/workflows/build-and-test.yml)
 
-# apm-agent-ios : APM Agent for iOS
-This is the official iOS package for [Elastic APM](https://www.elastic.co/solutions/apm)
+# EDOT iOS
+The Elastic Distribution of OpenTelemetry iOS (EDOT iOS) is the OpenTelemetry-based SDK for iOS apps.
 
-<!-- TO DO: Update when new instructions are ready -->
 ## Documentation
 
-Visit [elastic.co](https://www.elastic.co/guide/en/apm/agent/swift/current/index.html) for the iOS agent documentation.
-
-To build this project's documentation locally, you must first clone the [`elastic/docs` repository](https://github.com/elastic/docs/). Then run the following commands:
-
-```bash
-# Set the location of your repositories
-export GIT_HOME="/<fullPathToYourRepos>"
-# Build the APM iOS documentation
-$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-ios/docs/index.asciidoc --chunk 1 --open
-```
+Read the [EDOT iOS documentation](https://www.elastic.co/docs/reference/opentelemetry/edot-sdks/ios).
 
 ## Notes
 

--- a/docs/reference/edot-ios/automatic-instrumentation.md
+++ b/docs/reference/edot-ios/automatic-instrumentation.md
@@ -154,20 +154,30 @@ Crash reports are sent on the next app launch, not at the time of the crash.
 
 ### System metrics [system-metrics]
 
+```{applies_to}
+product:
+  edot_ios: ga 2.1.0
+```
+
 EDOT iOS records app CPU and memory usage:
 
-| Metric | Description | Unit |
-| --- | --- | --- |
-| `system.cpu.usage` | CPU used by the app's active threads | Percentage |
-| `system.memory.usage` | Physical memory footprint of the app process | Bytes |
+| Metric | Description | Instrument | Unit | Attributes |
+| --- | --- | --- | --- | --- |
+| `process.cpu.utilization` | Sum of the app's per-thread CPU percentages divided by 100 and by the active processor count, clamped to 0–1 | Observable gauge | `1` | `cpu.mode=total` |
+| `process.memory.usage` | Physical memory footprint of the app process | Observable up-down counter | `By` | None |
 
-Both metrics include the attribute `state=app`.
+To restore the legacy metric names and output, see [`useLegacyAttributeNames(_:)`](configuration.md#useLegacyAttributeNames).
 
 ### Application lifecycle events [app-lifecycle-events]
 
-EDOT iOS creates `lifecycle` log events when the app changes state.
+```{applies_to}
+product:
+  edot_ios: ga 2.1.0
+```
 
-The `lifecycle.state` attribute can have the following values:
+EDOT iOS creates `device.app.lifecycle` log events when the app changes state.
+
+The `ios.app.state` attribute can have the following values:
 
 | Value | App transition |
 | --- | --- |
@@ -176,6 +186,8 @@ The `lifecycle.state` attribute can have the following values:
 | `background` | The app entered the background. |
 | `foreground` | The app is about to enter the foreground. |
 | `terminate` | The app is about to terminate. |
+
+To restore the legacy event name and attribute, see [`useLegacyAttributeNames(_:)`](configuration.md#useLegacyAttributeNames).
 
 ## Understanding automatic-instrumentation scope [automatic-instrumentation-scope]
 

--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -55,7 +55,7 @@ let configuration = AgentConfigBuilder()
 | --- | --- |
 | `URL` | Yes |
 
-Sets the required OTLP endpoint provided by an Elastic Agent or EDOT Collector gateway.
+Sets the required OTLP endpoint provided by an Elastic Agent OTLP endpoint or the Elastic Cloud Managed OTLP Endpoint.
 An enabled agent does not start without a valid `http` or `https` URL with a host.
 
 When the connection type is `.http`, EDOT iOS appends `/v1/traces`, `/v1/metrics`, or `/v1/logs` to the configured path for each signal. When the connection type is `.grpc`, all signals use the configured gRPC endpoint.
@@ -74,8 +74,8 @@ Selects the OTLP transport:
 OTLP/HTTP is the default. Use `.useConnectionType(.grpc)` only when the OTLP
 endpoint requires gRPC. The export URL controls security: `https` enables TLS
 and `http` uses plaintext. Make sure the endpoint supports the selected
-transport. EDOT Collector commonly listens on port `4317` for gRPC and `4318`
-for HTTP.
+transport. An Elastic OTLP endpoint commonly listens on port `4317` for
+gRPC and `4318` for HTTP.
 
 #### `withServerUrl(_:)` [withServerUrl]
 
@@ -149,7 +149,7 @@ Refer to [APM secret tokens](docs-content://solutions/observability/apm/secret-t
 
 ### Remote management connectivity [remote-management-connectivity]
 
-EDOT iOS retrieves central configuration from an EDOT Collector through an OpAMP endpoint.
+EDOT iOS retrieves central configuration from Elastic's OpAMP endpoint.
 
 #### `withManagementUrl(_:)` [withManagementUrl]
 
@@ -163,7 +163,7 @@ Sets the OpAMP endpoint used for central configuration. Set it explicitly and en
 let configuration = AgentConfigBuilder()
   .withExportUrl(URL(string: "https://your-otlp-endpoint")!)
   .withManagementUrl(
-    URL(string: "https://your-edot-collector:4320/v1/opamp")!
+    URL(string: "https://your-opamp-endpoint:4320/v1/opamp")!
   )
   .useOpAMP()
   .build()
@@ -524,15 +524,15 @@ product:
   edot_ios: preview 1.4.0
 ```
 
-EDOT iOS receives central configuration from an EDOT Collector through OpAMP.
+EDOT iOS receives central configuration from Elastic through OpAMP.
 
-To use an EDOT Collector OpAMP endpoint:
+To use an Elastic OpAMP endpoint:
 
 ```swift
 let configuration = AgentConfigBuilder()
   .withExportUrl(URL(string: "https://your-otlp-endpoint")!)
   .withManagementUrl(
-    URL(string: "https://your-edot-collector:4320/v1/opamp")!
+    URL(string: "https://your-opamp-endpoint:4320/v1/opamp")!
   )
   .withApiKey("your-api-key")
   .useOpAMP()
@@ -541,7 +541,7 @@ let configuration = AgentConfigBuilder()
 ElasticApmAgent.start(with: configuration)
 ```
 
-Refer to [Central configuration for EDOT SDKs](opentelemetry://reference/central-configuration.md) for EDOT Collector and {{kib}} setup.
+Refer to [Central configuration for EDOT SDKs](opentelemetry://reference/central-configuration.md) for Elastic Agent and {{kib}} setup.
 
 ### Available settings [central-configuration-settings]
 

--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -149,7 +149,7 @@ Refer to [APM secret tokens](docs-content://solutions/observability/apm/secret-t
 
 ### Remote management connectivity [remote-management-connectivity]
 
-EDOT iOS retrieves central configuration from Elastic's OpAMP endpoint.
+EDOT iOS retrieves central configuration from a central configuration (OpAMP) endpoint.
 
 #### `withManagementUrl(_:)` [withManagementUrl]
 
@@ -524,9 +524,9 @@ product:
   edot_ios: preview 1.4.0
 ```
 
-EDOT iOS receives central configuration from Elastic through OpAMP.
+EDOT iOS receives central configuration from a central configuration (OpAMP) endpoint.
 
-To use an Elastic OpAMP endpoint:
+To use an OpAMP endpoint:
 
 ```swift
 let configuration = AgentConfigBuilder()

--- a/docs/reference/edot-ios/getting-started.md
+++ b/docs/reference/edot-ios/getting-started.md
@@ -26,7 +26,7 @@ Set up the Elastic Distribution of OpenTelemetry iOS (EDOT iOS) in your app and 
 | Swift | 5.10 |
 | iOS | 16 |
 
-You also need a reachable OpenTelemetry Protocol (OTLP) endpoint provided by an [Elastic Agent or EDOT Collector gateway](elastic-agent://reference/edot-collector/modes.md#edot-collector-as-gateway).
+You also need a reachable OpenTelemetry Protocol (OTLP) endpoint provided by an [Elastic Agent OTLP endpoint](elastic-agent://reference/edot-collector/modes.md#edot-collector-as-gateway).
 
 ## Add the SDK dependency [add-agent-dependency]
 


### PR DESCRIPTION
## Summary

- Refresh the iOS SDK front door with EDOT branding and current documentation links.
- Update OTLP and OpAMP endpoint wording and examples.
- Align automatic-instrumentation documentation with current metric and lifecycle output, including 2.1.0 applicability tags and legacy-name guidance.

## Verification

- `docs-builder --strict`
- Targeted documentation acceptance checks