### PR TITLE
fix: use central configuration sample rate key

### DIFF
--- a/Sources/Tests/apm-agent-iosTests/CentralConfigTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/CentralConfigTests.swift
@@ -23,13 +23,13 @@ class CentralConfigTests: XCTestCase {
   let withRecording = """
     {
         "recording": "true",
-        "sampleRate": 1.0
+        "session_sample_rate": 1.0
     }
     """
   let withoutRecording = """
     {
         "recording": "false",
-        "sampleRate": 0.5
+        "session_sample_rate": 0.5
     }
     """
 
@@ -37,7 +37,7 @@ class CentralConfigTests: XCTestCase {
     {
         "recording" : "false",
         "new" : "new",
-      "sampleRate" : 0.0
+      "session_sample_rate" : 0.0
     }
     """
 
@@ -101,6 +101,19 @@ class CentralConfigTests: XCTestCase {
     let three = CentralConfig()
 
     XCTAssertFalse(three.data.recording)
+  }
+
+  func testLegacySampleRateKeyIsIgnored() throws {
+    let legacyConfig = """
+      {
+          "sampleRate": 0.5
+      }
+      """
+
+    let data = try XCTUnwrap(legacyConfig.data(using: .utf8))
+    let config = try JSONDecoder().decode(CentralConfigData.self, from: data)
+
+    XCTAssertNil(config.sampleRate)
   }
 
   func testMaxAgeParse() {

--- a/Sources/Tests/apm-agent-iosTests/CentralConfigTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/CentralConfigTests.swift
@@ -23,13 +23,13 @@ class CentralConfigTests: XCTestCase {
   let withRecording = """
     {
         "recording": "true",
-        "session_sample_rate": 1.0
+        "session_sample_rate": "1.0"
     }
     """
   let withoutRecording = """
     {
         "recording": "false",
-        "session_sample_rate": 0.5
+        "session_sample_rate": "0.5"
     }
     """
 
@@ -37,7 +37,7 @@ class CentralConfigTests: XCTestCase {
     {
         "recording" : "false",
         "new" : "new",
-      "session_sample_rate" : 0.0
+      "session_sample_rate" : "0.0"
     }
     """
 
@@ -114,6 +114,19 @@ class CentralConfigTests: XCTestCase {
     let config = try JSONDecoder().decode(CentralConfigData.self, from: data)
 
     XCTAssertNil(config.sampleRate)
+  }
+
+  func testNumericSessionSampleRateValue() throws {
+    let numericConfig = """
+      {
+          "session_sample_rate": 0.5
+      }
+      """
+
+    let data = try XCTUnwrap(numericConfig.data(using: .utf8))
+    let config = try JSONDecoder().decode(CentralConfigData.self, from: data)
+
+    XCTAssertEqual(config.sampleRate, 0.5)
   }
 
   func testMaxAgeParse() {

--- a/Sources/Tests/apm-agent-iosTests/Opamp/OpampClientImplTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/Opamp/OpampClientImplTests.swift
@@ -83,7 +83,7 @@ public class OpampClientImplTests: XCTestCase {
       let config_json = """
         {
           "recording" : true,
-          "sampleRate": 0.9
+          "session_sample_rate": 0.9
         }
         """
       var agentConfigFile = Opamp_Proto_AgentConfigFile()

--- a/Sources/Tests/apm-agent-iosTests/Opamp/OpampClientImplTests.swift
+++ b/Sources/Tests/apm-agent-iosTests/Opamp/OpampClientImplTests.swift
@@ -82,8 +82,8 @@ public class OpampClientImplTests: XCTestCase {
 
       let config_json = """
         {
-          "recording" : true,
-          "session_sample_rate": 0.9
+          "recording" : "false",
+          "session_sample_rate": "0.9"
         }
         """
       var agentConfigFile = Opamp_Proto_AgentConfigFile()

--- a/Sources/apm-agent-ios/Configuration/CentralConfigData.swift
+++ b/Sources/apm-agent-ios/Configuration/CentralConfigData.swift
@@ -33,9 +33,13 @@ public struct CentralConfigData: Codable {
       recording = true
     }
 
-    do {
-      sampleRate = try values.decode(Double.self, forKey: .sampleRate)
-    } catch {}
+    if let numericValue = try? values.decode(Double.self, forKey: .sampleRate) {
+      sampleRate = numericValue
+    } else if let stringValue = try? values.decode(String.self, forKey: .sampleRate) {
+      sampleRate = Double(stringValue)
+    } else {
+      sampleRate = nil
+    }
   }
 
   init() {}

--- a/Sources/apm-agent-ios/Configuration/CentralConfigData.swift
+++ b/Sources/apm-agent-ios/Configuration/CentralConfigData.swift
@@ -21,7 +21,7 @@ public struct CentralConfigData: Codable {
 
   enum CodingKeys: String, CodingKey {
     case recording
-    case sampleRate
+    case sampleRate = "session_sample_rate"
   }
 
   public init(from decoder: Decoder) throws {

--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -545,9 +545,9 @@ Refer to [Central configuration for EDOT SDKs](opentelemetry://reference/central
 
 ### Available settings [central-configuration-settings]
 
-{applies_to}`edot_ios: ga 2.1.0` The OpAMP `elastic` config map uses the JSON keys shown below.
+{applies_to}`edot_ios: ga 2.1.0` The OpAMP `elastic` config map uses these keys.
 
-| Setting | JSON key | Description | Type |
+| Setting | Key | Description | Type |
 | --- | --- | --- | --- |
 | Recording | `recording` | Whether EDOT iOS processes and exports log records. | Dynamic |
 | Session sample rate | `session_sample_rate` | The probability that spans from a new session are sampled. | Dynamic |

--- a/docs/reference/edot-ios/configuration.md
+++ b/docs/reference/edot-ios/configuration.md
@@ -545,7 +545,9 @@ Refer to [Central configuration for EDOT SDKs](opentelemetry://reference/central
 
 ### Available settings [central-configuration-settings]
 
-| Setting | Description | Type |
-| --- | --- | --- |
-| Recording | Whether EDOT iOS processes and exports log records. | Dynamic |
-| Session sample rate | The probability that spans from a new session are sampled. | Dynamic |
+{applies_to}`edot_ios: ga 2.1.0` The OpAMP `elastic` config map uses the JSON keys shown below.
+
+| Setting | JSON key | Description | Type |
+| --- | --- | --- | --- |
+| Recording | `recording` | Whether EDOT iOS processes and exports log records. | Dynamic |
+| Session sample rate | `session_sample_rate` | The probability that spans from a new session are sampled. | Dynamic |


### PR DESCRIPTION
## Summary

Align central configuration decoding with the string-valued settings delivered through OpAMP.

## Changes

- Decode the canonical `session_sample_rate` key and parse string-form values as `Double` while retaining numeric compatibility.
- Keep string-to-Boolean parsing for `recording` and update central configuration fixtures and regression coverage.
- Document the setting keys delivered through the OpAMP `elastic` config map.